### PR TITLE
Implement login and admin panel

### DIFF
--- a/backend/data/users.json
+++ b/backend/data/users.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": "u1",
+    "username": "admin",
+    "password": "$2b$10$sZP2uKzUbn6j8nIgsxtCnubwijXqfuyZ6ZpreLr9SYcPARGh4YOsG",
+    "role": "admin",
+    "name": "Admin",
+    "departmentId": ""
+  }
+]

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title data-i18n="title">TicketBox - Fault Management</title>
+  <style>
+    table, th, td { border: 1px solid #ccc; border-collapse: collapse; padding: 4px; }
+    form { margin-bottom: 1em; }
+  </style>
+</head>
+<body>
+  <button id="langToggle" style="float:right"></button>
+  <h1 data-i18n="title">TicketBox - Fault Management</h1>
+
+
+  <h2 data-i18n="manageDepartments">Manage Departments</h2>
+  <form id="deptForm">
+    <input type="text" id="newDept" required />
+    <button type="submit" data-i18n="submit">Add</button>
+  </form>
+  <ul id="deptList"></ul>
+
+  <h2 data-i18n="manageStaff">Manage Staff</h2>
+  <form id="staffForm">
+    <input type="text" id="newStaff" required />
+    <select id="staffDept"></select>
+    <button type="submit" data-i18n="submit">Add</button>
+  </form>
+  <ul id="staffList"></ul>
+
+  <h2 data-i18n="manageUsers">Manage Users</h2>
+  <form id="userForm">
+    <input type="text" id="newUsername" placeholder="login" required />
+    <input type="password" id="newPassword" placeholder="password" required />
+    <input type="text" id="newName" placeholder="name" required />
+    <select id="userDept"></select>
+    <select id="userRole">
+      <option value="user">User</option>
+      <option value="admin">Admin</option>
+    </select>
+    <button type="submit" data-i18n="submit">Add</button>
+  </form>
+  <ul id="userList"></ul>
+
+<script>
+let currentUser = null;
+async function requireLogin(){
+  const res = await fetch('/api/me');
+  if(!res.ok){
+    window.location.href = '/';
+    return;
+  }
+  const u = await res.json();
+  if(u.role !== 'admin') { window.location.href = '/'; return; }
+  currentUser = u;
+}
+requireLogin();
+const translations = {
+  en: {
+    title: 'TicketBox - Fault Management',
+    newTicket: 'New Ticket',
+    description: 'Description',
+    department: 'Department',
+    room: 'Room',
+    user: 'User',
+    submit: 'Add Ticket',
+    tickets: 'Tickets',
+    filterRoom: 'Filter by room',
+    refresh: 'Refresh',
+    id: 'ID',
+    status: 'Status',
+    actions: 'Actions',
+    openedBy: 'Opened by',
+    closedBy: 'Closed by',
+    selectDepartment: 'Select Department',
+    selectUser: 'Select User',
+    manageDepartments: 'Manage Departments',
+    manageStaff: 'Manage Staff',
+    manageUsers: 'Manage Users',
+    openStatus: 'Open',
+      closedStatus: 'Closed',
+      close: 'Close',
+      openedAt: 'Opened at',
+      closedAt: 'Closed at'
+    },
+    he: {
+    title: 'TicketBox - \u05DE\u05E2\u05E8\u05DB\u05EA \u05DC\u05E0\u05D9\u05D4\u05D5\u05DC \u05EA\u05E7\u05DC\u05D5\u05EA',
+    newTicket: '\u05EA\u05E7\u05DC\u05D4 \u05D7\u05D3\u05E9\u05D4',
+    description: '\u05EA\u05D9\u05D0\u05D5\u05E8',
+    department: '\u05DE\u05D7\u05DC\u05E7\u05D4',
+    room: '\u05D7\u05D3\u05E8',
+    user: '\u05DE\u05E9\u05EA\u05DE\u05E9',
+    submit: '\u05D4\u05D5\u05E1\u05E3 \u05EA\u05E7\u05DC\u05D4',
+    tickets: '\u05E8\u05E9\u05D9\u05DE\u05EA \u05EA\u05E7\u05DC\u05D5\u05EA',
+    filterRoom: '\u05E1\u05D9\u05E0\u05D5\u05DF \u05DC\u05E4\u05D9 \u05D7\u05D3\u05E8',
+    refresh: '\u05E8\u05E2\u05E0\u05DF',
+    id: '\u05DE\u05D6\u05D4\u05D4',
+    status: '\u05E1\u05D8\u05D8\u05D5\u05E1',
+    actions: '\u05E4\u05E2\u05D5\u05DC\u05D5\u05EA',
+    openStatus: '\u05E4\u05EA\u05D5\u05D7\u05D4',
+      closedStatus: '\u05E1\u05D2\u05D5\u05E8\u05D4',
+      close: '\u05E1\u05D2\u05D5\u05E8',
+      openedAt: '\u05EA\u05D0\u05E8\u05D9\u05DA \u05E4\u05EA\u05D9\u05D7\u05D4',
+      closedAt: '\u05EA\u05D0\u05E8\u05D9\u05DA \u05E1\u05D2\u05D9\u05E8\u05D4',
+      openedBy: '\u05E0\u05E4\u05EA\u05D7 \u05E2\u05DC \u05D9\u05D3\u05D9',
+      closedBy: '\u05E0\u05E1\u05D2\u05E8 \u05E2\u05DC \u05D9\u05D3\u05D9',
+      selectDepartment: '\u05D1\u05D7\u05E8 \u05DE\u05D7\u05DC\u05E7\u05D4',
+      selectUser: '\u05D1\u05D7\u05E8 \u05E2\u05D5\u05D1\u05D3',
+      manageDepartments: '\u05E0\u05D9\u05D4\u05D5\u05DC \u05DE\u05D7\u05DC\u05E7\u05D5\u05EA',
+      manageStaff: '\u05E0\u05D9\u05D4\u05D5\u05DC \u05E2\u05D5\u05D1\u05D3\u05D9\u05DD',
+      manageUsers: '\u05E0\u05D9\u05D4\u05D5\u05DC \u05DE\u05E9\u05EA\u05DE\u05E9\u05D9\u05DD'
+    }
+  };
+
+let currentLang = 'en';
+let departments = [];
+let staff = [];
+
+function t(key) {
+  return translations[currentLang][key] || key;
+}
+
+function applyTranslations() {
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    el.textContent = t(el.dataset.i18n);
+  });
+  document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+    el.placeholder = t(el.dataset.i18nPlaceholder);
+  });
+  document.getElementById('langToggle').textContent = currentLang === 'he' ? '🇬🇧 English' : '🇮🇱 עברית';
+  document.documentElement.lang = currentLang;
+  document.documentElement.dir = currentLang === 'he' ? 'rtl' : 'ltr';
+}
+
+function setLang(lang) {
+  currentLang = lang;
+  localStorage.setItem('lang', lang);
+  applyTranslations();
+  loadTickets();
+  loadUsersList();
+}
+
+function getLang() {
+  const stored = localStorage.getItem('lang');
+  if (stored) return stored;
+  return navigator.language && navigator.language.startsWith('he') ? 'he' : 'en';
+}
+
+document.getElementById('langToggle').addEventListener('click', () => {
+  setLang(currentLang === 'en' ? 'he' : 'en');
+});
+
+async function loadDepartmentsList() {
+  const res = await fetch('/api/departments');
+  departments = await res.json();
+  const select = document.getElementById('deptSelect');
+  if (select) {
+    select.innerHTML = `<option value="">${t('selectDepartment')}</option>`;
+    departments.forEach(d => {
+      const opt = document.createElement('option');
+      opt.value = d.id;
+      opt.textContent = d.name;
+      select.appendChild(opt);
+    });
+  }
+  renderDeptList();
+}
+
+async function loadStaffList(deptId, targetId='userSelect') {
+  const res = await fetch('/api/staff' + (deptId ? `?departmentId=${deptId}` : ''));
+  const data = await res.json();
+  if (!deptId) { staff = data; renderStaffList(); return; }
+  const select = document.getElementById(targetId);
+  if (!select) return;
+  select.innerHTML = `<option value="">${t('selectUser')}</option>`;
+  data.forEach(u => {
+    const opt = document.createElement('option');
+    opt.value = u.id;
+    opt.textContent = u.name;
+    select.appendChild(opt);
+  });
+}
+
+document.getElementById('deptSelect').addEventListener('change', e => {
+  loadStaffList(e.target.value);
+});
+document.getElementById('closeDept').addEventListener('change', e => {
+  loadStaffList(e.target.value, 'closeUser');
+});
+
+function renderDeptList() {
+  const ul = document.getElementById('deptList');
+  if (!ul) return;
+  ul.innerHTML = '';
+  departments.forEach(d => {
+    const li = document.createElement('li');
+    li.textContent = d.name;
+    const del = document.createElement('button');
+    del.textContent = 'x';
+    del.onclick = async () => {
+      await fetch(`/api/departments/${d.id}`, {method:'DELETE'});
+      loadTickets();
+    };
+    li.appendChild(del);
+    ul.appendChild(li);
+  });
+  const staffDept = document.getElementById('staffDept');
+  if (staffDept) {
+    staffDept.innerHTML = '';
+    departments.forEach(d => {
+      const opt = document.createElement('option');
+      opt.value = d.id;
+      opt.textContent = d.name;
+      staffDept.appendChild(opt);
+    });
+  }
+}
+
+function renderStaffList() {
+  const ul = document.getElementById('staffList');
+  if (!ul) return;
+  ul.innerHTML = '';
+  staff.forEach(s => {
+    const li = document.createElement('li');
+    const dept = departments.find(d => d.id === s.departmentId);
+    li.textContent = `${s.name} (${dept ? dept.name : ''})`;
+    const del = document.createElement('button');
+    del.textContent = 'x';
+    del.onclick = async () => {
+      await fetch(`/api/staff/${s.id}`, {method:'DELETE'});
+      loadTickets();
+    };
+    li.appendChild(del);
+    ul.appendChild(li);
+  });
+}
+
+let users = [];
+
+async function loadUsersList() {
+  const res = await fetch('/api/users');
+  users = await res.json();
+  const deptSel = document.getElementById('userDept');
+  if (deptSel) {
+    deptSel.innerHTML = '';
+    departments.forEach(d => {
+      const opt = document.createElement('option');
+      opt.value = d.id;
+      opt.textContent = d.name;
+      deptSel.appendChild(opt);
+    });
+  }
+  renderUserList();
+}
+
+function renderUserList() {
+  const ul = document.getElementById('userList');
+  if (!ul) return;
+  ul.innerHTML = '';
+  users.forEach(u => {
+    const li = document.createElement('li');
+    const dept = departments.find(d => d.id === u.departmentId);
+    li.textContent = `${u.username} (${u.role}) - ${u.name}${dept ? ' ('+dept.name+')' : ''}`;
+    const del = document.createElement('button');
+    del.textContent = 'x';
+    del.onclick = async () => {
+      await fetch(`/api/users/${u.id}`, {method:'DELETE'});
+      loadUsersList();
+    };
+    li.appendChild(del);
+    ul.appendChild(li);
+  });
+}
+
+async function loadTickets() {
+  await loadDepartmentsList();
+  await loadStaffList();
+}
+
+
+setLang(getLang());
+loadUsersList();
+
+document.getElementById('deptForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  await fetch('/api/departments', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({name: document.getElementById('newDept').value})});
+  e.target.reset();
+  loadTickets();
+});
+
+document.getElementById('staffForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const body = {
+    name: document.getElementById('newStaff').value,
+    departmentId: document.getElementById('staffDept').value
+  };
+  await fetch('/api/staff', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
+  e.target.reset();
+  loadTickets();
+});
+
+const userForm = document.getElementById('userForm');
+if (userForm) {
+  userForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    const body = {
+      username: document.getElementById('newUsername').value,
+      password: document.getElementById('newPassword').value,
+      name: document.getElementById('newName').value,
+      departmentId: document.getElementById('userDept').value,
+      role: document.getElementById('userRole').value
+    };
+    await fetch('/api/users', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
+    e.target.reset();
+    loadUsersList();
+  });
+}
+
+</script>
+</body>
+</html>

--- a/frontend/app.html
+++ b/frontend/app.html
@@ -1,0 +1,339 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title data-i18n="title">TicketBox - Fault Management</title>
+  <style>
+    table, th, td { border: 1px solid #ccc; border-collapse: collapse; padding: 4px; }
+    form { margin-bottom: 1em; }
+  </style>
+</head>
+<body>
+  <button id="langToggle" style="float:right"></button>
+  <h1 data-i18n="title">TicketBox - Fault Management</h1>
+
+  <h2 data-i18n="newTicket">New Ticket</h2>
+  <form id="addForm">
+    <textarea id="desc" data-i18n-placeholder="description" required></textarea>
+    <select id="deptSelect" required></select>
+    <select id="userSelect" required></select>
+    <input type="text" id="room" data-i18n-placeholder="room" required />
+    <button type="submit" data-i18n="submit">Add Ticket</button>
+  </form>
+
+  <h2 data-i18n="tickets">Tickets</h2>
+  <label><span data-i18n="filterRoom">Filter by room</span>: <input type="text" id="filterRoom" /></label>
+  <button onclick="loadTickets()" data-i18n="refresh">Refresh</button>
+  <table id="tickets">
+    <thead>
+      <tr>
+        <th data-i18n="id">ID</th>
+        <th data-i18n="description">Description</th>
+        <th data-i18n="room">Room</th>
+        <th data-i18n="department">Department</th>
+        <th data-i18n="openedBy">Opened by</th>
+        <th data-i18n="closedBy">Closed by</th>
+        <th data-i18n="openedAt">Opened at</th>
+        <th data-i18n="closedAt">Closed at</th>
+        <th data-i18n="status">Status</th>
+        <th data-i18n="actions">Actions</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+
+  <form id="closeForm" style="display:none;">
+    <select id="closeDept"></select>
+    <select id="closeUser"></select>
+    <input type="text" id="closeComment" placeholder="comment" />
+    <button type="submit" data-i18n="close">Close</button>
+  </form>
+
+
+
+<script>
+let currentUser = null;
+async function requireLogin(){
+  const res = await fetch('/api/me');
+  if(!res.ok){
+    window.location.href = '/';
+    return;
+  }
+  currentUser = await res.json();
+  if(currentUser.role === 'admin'){
+    const a = document.createElement('a');
+    a.href = '/admin.html';
+    a.textContent = 'Admin';
+    document.body.prepend(a);
+  }
+}
+requireLogin();
+const translations = {
+  en: {
+    title: 'TicketBox - Fault Management',
+    newTicket: 'New Ticket',
+    description: 'Description',
+    department: 'Department',
+    room: 'Room',
+    user: 'User',
+    submit: 'Add Ticket',
+    tickets: 'Tickets',
+    filterRoom: 'Filter by room',
+    refresh: 'Refresh',
+    id: 'ID',
+    status: 'Status',
+    actions: 'Actions',
+    openedBy: 'Opened by',
+    closedBy: 'Closed by',
+    selectDepartment: 'Select Department',
+    selectUser: 'Select User',
+    manageDepartments: 'Manage Departments',
+    manageStaff: 'Manage Staff',
+    openStatus: 'Open',
+      closedStatus: 'Closed',
+      close: 'Close',
+      openedAt: 'Opened at',
+      closedAt: 'Closed at'
+    },
+    he: {
+    title: 'TicketBox - \u05DE\u05E2\u05E8\u05DB\u05EA \u05DC\u05E0\u05D9\u05D4\u05D5\u05DC \u05EA\u05E7\u05DC\u05D5\u05EA',
+    newTicket: '\u05EA\u05E7\u05DC\u05D4 \u05D7\u05D3\u05E9\u05D4',
+    description: '\u05EA\u05D9\u05D0\u05D5\u05E8',
+    department: '\u05DE\u05D7\u05DC\u05E7\u05D4',
+    room: '\u05D7\u05D3\u05E8',
+    user: '\u05DE\u05E9\u05EA\u05DE\u05E9',
+    submit: '\u05D4\u05D5\u05E1\u05E3 \u05EA\u05E7\u05DC\u05D4',
+    tickets: '\u05E8\u05E9\u05D9\u05DE\u05EA \u05EA\u05E7\u05DC\u05D5\u05EA',
+    filterRoom: '\u05E1\u05D9\u05E0\u05D5\u05DF \u05DC\u05E4\u05D9 \u05D7\u05D3\u05E8',
+    refresh: '\u05E8\u05E2\u05E0\u05DF',
+    id: '\u05DE\u05D6\u05D4\u05D4',
+    status: '\u05E1\u05D8\u05D8\u05D5\u05E1',
+    actions: '\u05E4\u05E2\u05D5\u05DC\u05D5\u05EA',
+    openStatus: '\u05E4\u05EA\u05D5\u05D7\u05D4',
+      closedStatus: '\u05E1\u05D2\u05D5\u05E8\u05D4',
+      close: '\u05E1\u05D2\u05D5\u05E8',
+      openedAt: '\u05EA\u05D0\u05E8\u05D9\u05DA \u05E4\u05EA\u05D9\u05D7\u05D4',
+      closedAt: '\u05EA\u05D0\u05E8\u05D9\u05DA \u05E1\u05D2\u05D9\u05E8\u05D4',
+      openedBy: '\u05E0\u05E4\u05EA\u05D7 \u05E2\u05DC \u05D9\u05D3\u05D9',
+      closedBy: '\u05E0\u05E1\u05D2\u05E8 \u05E2\u05DC \u05D9\u05D3\u05D9',
+      selectDepartment: '\u05D1\u05D7\u05E8 \u05DE\u05D7\u05DC\u05E7\u05D4',
+      selectUser: '\u05D1\u05D7\u05E8 \u05E2\u05D5\u05D1\u05D3',
+      manageDepartments: '\u05E0\u05D9\u05D4\u05D5\u05DC \u05DE\u05D7\u05DC\u05E7\u05D5\u05EA',
+      manageStaff: '\u05E0\u05D9\u05D4\u05D5\u05DC \u05E2\u05D5\u05D1\u05D3\u05D9\u05DD'
+    }
+  };
+
+let currentLang = 'en';
+let departments = [];
+let staff = [];
+
+function t(key) {
+  return translations[currentLang][key] || key;
+}
+
+function applyTranslations() {
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    el.textContent = t(el.dataset.i18n);
+  });
+  document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+    el.placeholder = t(el.dataset.i18nPlaceholder);
+  });
+  document.getElementById('langToggle').textContent = currentLang === 'he' ? '🇬🇧 English' : '🇮🇱 עברית';
+  document.documentElement.lang = currentLang;
+  document.documentElement.dir = currentLang === 'he' ? 'rtl' : 'ltr';
+}
+
+function setLang(lang) {
+  currentLang = lang;
+  localStorage.setItem('lang', lang);
+  applyTranslations();
+  loadTickets();
+}
+
+function getLang() {
+  const stored = localStorage.getItem('lang');
+  if (stored) return stored;
+  return navigator.language && navigator.language.startsWith('he') ? 'he' : 'en';
+}
+
+document.getElementById('langToggle').addEventListener('click', () => {
+  setLang(currentLang === 'en' ? 'he' : 'en');
+});
+
+async function loadDepartmentsList() {
+  const res = await fetch('/api/departments');
+  departments = await res.json();
+  const select = document.getElementById('deptSelect');
+  if (select) {
+    select.innerHTML = `<option value="">${t('selectDepartment')}</option>`;
+    departments.forEach(d => {
+      const opt = document.createElement('option');
+      opt.value = d.id;
+      opt.textContent = d.name;
+      select.appendChild(opt);
+    });
+  }
+  renderDeptList();
+}
+
+async function loadStaffList(deptId, targetId='userSelect') {
+  const res = await fetch('/api/staff' + (deptId ? `?departmentId=${deptId}` : ''));
+  const data = await res.json();
+  if (!deptId) { staff = data; renderStaffList(); return; }
+  const select = document.getElementById(targetId);
+  if (!select) return;
+  select.innerHTML = `<option value="">${t('selectUser')}</option>`;
+  data.forEach(u => {
+    const opt = document.createElement('option');
+    opt.value = u.id;
+    opt.textContent = u.name;
+    select.appendChild(opt);
+  });
+}
+
+document.getElementById('deptSelect').addEventListener('change', e => {
+  loadStaffList(e.target.value);
+});
+document.getElementById('closeDept').addEventListener('change', e => {
+  loadStaffList(e.target.value, 'closeUser');
+});
+
+function renderDeptList() {
+  const ul = document.getElementById('deptList');
+  if (!ul) return;
+  ul.innerHTML = '';
+  departments.forEach(d => {
+    const li = document.createElement('li');
+    li.textContent = d.name;
+    const del = document.createElement('button');
+    del.textContent = 'x';
+    del.onclick = async () => {
+      await fetch(`/api/departments/${d.id}`, {method:'DELETE'});
+      loadTickets();
+    };
+    li.appendChild(del);
+    ul.appendChild(li);
+  });
+  const staffDept = document.getElementById('staffDept');
+  if (staffDept) {
+    staffDept.innerHTML = '';
+    departments.forEach(d => {
+      const opt = document.createElement('option');
+      opt.value = d.id;
+      opt.textContent = d.name;
+      staffDept.appendChild(opt);
+    });
+  }
+}
+
+function renderStaffList() {
+  const ul = document.getElementById('staffList');
+  if (!ul) return;
+  ul.innerHTML = '';
+  staff.forEach(s => {
+    const li = document.createElement('li');
+    const dept = departments.find(d => d.id === s.departmentId);
+    li.textContent = `${s.name} (${dept ? dept.name : ''})`;
+    const del = document.createElement('button');
+    del.textContent = 'x';
+    del.onclick = async () => {
+      await fetch(`/api/staff/${s.id}`, {method:'DELETE'});
+      loadTickets();
+    };
+    li.appendChild(del);
+    ul.appendChild(li);
+  });
+}
+
+async function loadTickets() {
+  await loadDepartmentsList();
+  await loadStaffList();
+  const room = document.getElementById('filterRoom').value;
+  const params = room ? '?room=' + encodeURIComponent(room) : '';
+  const res = await fetch('/api/tickets' + params);
+  const data = await res.json();
+  const tbody = document.querySelector('#tickets tbody');
+  tbody.innerHTML = '';
+  data.forEach(ticket => {
+    const tr = document.createElement('tr');
+    const opened = ticket.openedAt ? new Date(ticket.openedAt).toLocaleString(currentLang) : '';
+    const closed = ticket.closedAt ? new Date(ticket.closedAt).toLocaleString(currentLang) : '';
+    const dept = departments.find(d => d.id === ticket.departmentId);
+    const openedBy = staff.find(s => s.id === ticket.openedBy);
+    const closedBy = staff.find(s => s.id === ticket.closedBy);
+    tr.innerHTML = `<td>${ticket.id}</td><td>${ticket.description}</td><td>${ticket.room}</td><td>${dept ? dept.name : ''}</td><td>${openedBy ? openedBy.name : ''}</td><td>${closedBy ? closedBy.name : ''}</td><td>${opened}</td><td>${closed}</td><td>${ticket.closedAt ? t('closedStatus') : t('openStatus')}</td>`;
+    const actionTd = document.createElement('td');
+    if (!ticket.closedAt) {
+      const btn = document.createElement('button');
+      btn.textContent = t('close');
+      btn.onclick = () => closeTicket(ticket.id, ticket.departmentId);
+      actionTd.appendChild(btn);
+    }
+    tr.appendChild(actionTd);
+    tbody.appendChild(tr);
+  });
+}
+
+async function closeTicket(id, deptId) {
+  const form = document.getElementById('closeForm');
+  form.style.display = 'block';
+  form.dataset.id = id;
+  await loadDepartmentsList();
+  document.getElementById('closeDept').value = deptId;
+  loadStaffList(deptId, 'closeUser');
+}
+
+document.getElementById('addForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const body = {
+    description: document.getElementById('desc').value,
+    departmentId: document.getElementById('deptSelect').value,
+    room: document.getElementById('room').value,
+    openedBy: document.getElementById('userSelect').value
+  };
+  await fetch('/api/tickets', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
+  e.target.reset();
+  loadTickets();
+});
+
+setLang(getLang());
+
+const deptForm = document.getElementById('deptForm');
+if (deptForm) {
+  deptForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    await fetch('/api/departments', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({name: document.getElementById('newDept').value})});
+    e.target.reset();
+    loadTickets();
+  });
+}
+
+const staffForm = document.getElementById('staffForm');
+if (staffForm) {
+  staffForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    const body = {
+      name: document.getElementById('newStaff').value,
+      departmentId: document.getElementById('staffDept').value
+    };
+    await fetch('/api/staff', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
+    e.target.reset();
+    loadTickets();
+  });
+}
+
+document.getElementById('closeForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const id = e.target.dataset.id;
+  const body = {
+    userId: document.getElementById('closeUser').value,
+    comment: document.getElementById('closeComment').value
+  };
+  await fetch(`/api/tickets/${id}/close`, {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
+  e.target.style.display = 'none';
+  e.target.reset();
+  loadTickets();
+});
+</script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,329 +1,35 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <title data-i18n="title">TicketBox - Fault Management</title>
-  <style>
-    table, th, td { border: 1px solid #ccc; border-collapse: collapse; padding: 4px; }
-    form { margin-bottom: 1em; }
-  </style>
+  <meta charset="UTF-8">
+  <title>Login</title>
 </head>
 <body>
-  <button id="langToggle" style="float:right"></button>
-  <h1 data-i18n="title">TicketBox - Fault Management</h1>
-
-  <h2 data-i18n="newTicket">New Ticket</h2>
-  <form id="addForm">
-    <input type="text" id="desc" data-i18n-placeholder="description" required />
-    <select id="deptSelect" required></select>
-    <select id="userSelect" required></select>
-    <input type="text" id="room" data-i18n-placeholder="room" required />
-    <button type="submit" data-i18n="submit">Add Ticket</button>
+  <form id="loginForm">
+    <input type="text" id="username" placeholder="login" required />
+    <input type="password" id="password" placeholder="password" required />
+    <button type="submit">Login</button>
   </form>
-
-  <h2 data-i18n="tickets">Tickets</h2>
-  <label><span data-i18n="filterRoom">Filter by room</span>: <input type="text" id="filterRoom" /></label>
-  <button onclick="loadTickets()" data-i18n="refresh">Refresh</button>
-  <table id="tickets">
-    <thead>
-      <tr>
-        <th data-i18n="id">ID</th>
-        <th data-i18n="description">Description</th>
-        <th data-i18n="room">Room</th>
-        <th data-i18n="department">Department</th>
-        <th data-i18n="openedBy">Opened by</th>
-        <th data-i18n="closedBy">Closed by</th>
-        <th data-i18n="openedAt">Opened at</th>
-        <th data-i18n="closedAt">Closed at</th>
-        <th data-i18n="status">Status</th>
-        <th data-i18n="actions">Actions</th>
-      </tr>
-    </thead>
-    <tbody></tbody>
-  </table>
-
-  <form id="closeForm" style="display:none;">
-    <select id="closeDept"></select>
-    <select id="closeUser"></select>
-    <input type="text" id="closeComment" placeholder="comment" />
-    <button type="submit" data-i18n="close">Close</button>
-  </form>
-
-  <h2 data-i18n="manageDepartments">Manage Departments</h2>
-  <form id="deptForm">
-    <input type="text" id="newDept" required />
-    <button type="submit" data-i18n="submit">Add</button>
-  </form>
-  <ul id="deptList"></ul>
-
-  <h2 data-i18n="manageStaff">Manage Staff</h2>
-  <form id="staffForm">
-    <input type="text" id="newStaff" required />
-    <select id="staffDept"></select>
-    <button type="submit" data-i18n="submit">Add</button>
-  </form>
-  <ul id="staffList"></ul>
-
+  <div id="error" style="color:red"></div>
 <script>
-const translations = {
-  en: {
-    title: 'TicketBox - Fault Management',
-    newTicket: 'New Ticket',
-    description: 'Description',
-    department: 'Department',
-    room: 'Room',
-    user: 'User',
-    submit: 'Add Ticket',
-    tickets: 'Tickets',
-    filterRoom: 'Filter by room',
-    refresh: 'Refresh',
-    id: 'ID',
-    status: 'Status',
-    actions: 'Actions',
-    openedBy: 'Opened by',
-    closedBy: 'Closed by',
-    selectDepartment: 'Select Department',
-    selectUser: 'Select User',
-    manageDepartments: 'Manage Departments',
-    manageStaff: 'Manage Staff',
-    openStatus: 'Open',
-      closedStatus: 'Closed',
-      close: 'Close',
-      openedAt: 'Opened at',
-      closedAt: 'Closed at'
-    },
-    he: {
-    title: 'TicketBox - \u05DE\u05E2\u05E8\u05DB\u05EA \u05DC\u05E0\u05D9\u05D4\u05D5\u05DC \u05EA\u05E7\u05DC\u05D5\u05EA',
-    newTicket: '\u05EA\u05E7\u05DC\u05D4 \u05D7\u05D3\u05E9\u05D4',
-    description: '\u05EA\u05D9\u05D0\u05D5\u05E8',
-    department: '\u05DE\u05D7\u05DC\u05E7\u05D4',
-    room: '\u05D7\u05D3\u05E8',
-    user: '\u05DE\u05E9\u05EA\u05DE\u05E9',
-    submit: '\u05D4\u05D5\u05E1\u05E3 \u05EA\u05E7\u05DC\u05D4',
-    tickets: '\u05E8\u05E9\u05D9\u05DE\u05EA \u05EA\u05E7\u05DC\u05D5\u05EA',
-    filterRoom: '\u05E1\u05D9\u05E0\u05D5\u05DF \u05DC\u05E4\u05D9 \u05D7\u05D3\u05E8',
-    refresh: '\u05E8\u05E2\u05E0\u05DF',
-    id: '\u05DE\u05D6\u05D4\u05D4',
-    status: '\u05E1\u05D8\u05D8\u05D5\u05E1',
-    actions: '\u05E4\u05E2\u05D5\u05DC\u05D5\u05EA',
-    openStatus: '\u05E4\u05EA\u05D5\u05D7\u05D4',
-      closedStatus: '\u05E1\u05D2\u05D5\u05E8\u05D4',
-      close: '\u05E1\u05D2\u05D5\u05E8',
-      openedAt: '\u05EA\u05D0\u05E8\u05D9\u05DA \u05E4\u05EA\u05D9\u05D7\u05D4',
-      closedAt: '\u05EA\u05D0\u05E8\u05D9\u05DA \u05E1\u05D2\u05D9\u05E8\u05D4',
-      openedBy: '\u05E0\u05E4\u05EA\u05D7 \u05E2\u05DC \u05D9\u05D3\u05D9',
-      closedBy: '\u05E0\u05E1\u05D2\u05E8 \u05E2\u05DC \u05D9\u05D3\u05D9',
-      selectDepartment: '\u05D1\u05D7\u05E8 \u05DE\u05D7\u05DC\u05E7\u05D4',
-      selectUser: '\u05D1\u05D7\u05E8 \u05E2\u05D5\u05D1\u05D3',
-      manageDepartments: '\u05E0\u05D9\u05D4\u05D5\u05DC \u05DE\u05D7\u05DC\u05E7\u05D5\u05EA',
-      manageStaff: '\u05E0\u05D9\u05D4\u05D5\u05DC \u05E2\u05D5\u05D1\u05D3\u05D9\u05DD'
-    }
-  };
-
-let currentLang = 'en';
-let departments = [];
-let staff = [];
-
-function t(key) {
-  return translations[currentLang][key] || key;
-}
-
-function applyTranslations() {
-  document.querySelectorAll('[data-i18n]').forEach(el => {
-    el.textContent = t(el.dataset.i18n);
-  });
-  document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
-    el.placeholder = t(el.dataset.i18nPlaceholder);
-  });
-  document.getElementById('langToggle').textContent = currentLang === 'he' ? '🇬🇧 English' : '🇮🇱 עברית';
-  document.documentElement.lang = currentLang;
-  document.documentElement.dir = currentLang === 'he' ? 'rtl' : 'ltr';
-}
-
-function setLang(lang) {
-  currentLang = lang;
-  localStorage.setItem('lang', lang);
-  applyTranslations();
-  loadTickets();
-}
-
-function getLang() {
-  const stored = localStorage.getItem('lang');
-  if (stored) return stored;
-  return navigator.language && navigator.language.startsWith('he') ? 'he' : 'en';
-}
-
-document.getElementById('langToggle').addEventListener('click', () => {
-  setLang(currentLang === 'en' ? 'he' : 'en');
-});
-
-async function loadDepartmentsList() {
-  const res = await fetch('/api/departments');
-  departments = await res.json();
-  const select = document.getElementById('deptSelect');
-  if (select) {
-    select.innerHTML = `<option value="">${t('selectDepartment')}</option>`;
-    departments.forEach(d => {
-      const opt = document.createElement('option');
-      opt.value = d.id;
-      opt.textContent = d.name;
-      select.appendChild(opt);
-    });
-  }
-  renderDeptList();
-}
-
-async function loadStaffList(deptId, targetId='userSelect') {
-  const res = await fetch('/api/staff' + (deptId ? `?departmentId=${deptId}` : ''));
-  const data = await res.json();
-  if (!deptId) { staff = data; renderStaffList(); return; }
-  const select = document.getElementById(targetId);
-  if (!select) return;
-  select.innerHTML = `<option value="">${t('selectUser')}</option>`;
-  data.forEach(u => {
-    const opt = document.createElement('option');
-    opt.value = u.id;
-    opt.textContent = u.name;
-    select.appendChild(opt);
-  });
-}
-
-document.getElementById('deptSelect').addEventListener('change', e => {
-  loadStaffList(e.target.value);
-});
-document.getElementById('closeDept').addEventListener('change', e => {
-  loadStaffList(e.target.value, 'closeUser');
-});
-
-function renderDeptList() {
-  const ul = document.getElementById('deptList');
-  if (!ul) return;
-  ul.innerHTML = '';
-  departments.forEach(d => {
-    const li = document.createElement('li');
-    li.textContent = d.name;
-    const del = document.createElement('button');
-    del.textContent = 'x';
-    del.onclick = async () => {
-      await fetch(`/api/departments/${d.id}`, {method:'DELETE'});
-      loadTickets();
-    };
-    li.appendChild(del);
-    ul.appendChild(li);
-  });
-  const staffDept = document.getElementById('staffDept');
-  if (staffDept) {
-    staffDept.innerHTML = '';
-    departments.forEach(d => {
-      const opt = document.createElement('option');
-      opt.value = d.id;
-      opt.textContent = d.name;
-      staffDept.appendChild(opt);
-    });
+async function check(){
+  const res = await fetch('/api/me');
+  if(res.ok){
+    const u = await res.json();
+    window.location.href = u.role === 'admin' ? '/admin.html' : '/app.html';
   }
 }
-
-function renderStaffList() {
-  const ul = document.getElementById('staffList');
-  if (!ul) return;
-  ul.innerHTML = '';
-  staff.forEach(s => {
-    const li = document.createElement('li');
-    const dept = departments.find(d => d.id === s.departmentId);
-    li.textContent = `${s.name} (${dept ? dept.name : ''})`;
-    const del = document.createElement('button');
-    del.textContent = 'x';
-    del.onclick = async () => {
-      await fetch(`/api/staff/${s.id}`, {method:'DELETE'});
-      loadTickets();
-    };
-    li.appendChild(del);
-    ul.appendChild(li);
-  });
-}
-
-async function loadTickets() {
-  await loadDepartmentsList();
-  await loadStaffList();
-  const room = document.getElementById('filterRoom').value;
-  const params = room ? '?room=' + encodeURIComponent(room) : '';
-  const res = await fetch('/api/tickets' + params);
-  const data = await res.json();
-  const tbody = document.querySelector('#tickets tbody');
-  tbody.innerHTML = '';
-  data.forEach(ticket => {
-    const tr = document.createElement('tr');
-    const opened = ticket.openedAt ? new Date(ticket.openedAt).toLocaleString(currentLang) : '';
-    const closed = ticket.closedAt ? new Date(ticket.closedAt).toLocaleString(currentLang) : '';
-    const dept = departments.find(d => d.id === ticket.departmentId);
-    const openedBy = staff.find(s => s.id === ticket.openedBy);
-    const closedBy = staff.find(s => s.id === ticket.closedBy);
-    tr.innerHTML = `<td>${ticket.id}</td><td>${ticket.description}</td><td>${ticket.room}</td><td>${dept ? dept.name : ''}</td><td>${openedBy ? openedBy.name : ''}</td><td>${closedBy ? closedBy.name : ''}</td><td>${opened}</td><td>${closed}</td><td>${ticket.closedAt ? t('closedStatus') : t('openStatus')}</td>`;
-    const actionTd = document.createElement('td');
-    if (!ticket.closedAt) {
-      const btn = document.createElement('button');
-      btn.textContent = t('close');
-      btn.onclick = () => closeTicket(ticket.id, ticket.departmentId);
-      actionTd.appendChild(btn);
-    }
-    tr.appendChild(actionTd);
-    tbody.appendChild(tr);
-  });
-}
-
-async function closeTicket(id, deptId) {
-  const form = document.getElementById('closeForm');
-  form.style.display = 'block';
-  form.dataset.id = id;
-  await loadDepartmentsList();
-  document.getElementById('closeDept').value = deptId;
-  loadStaffList(deptId, 'closeUser');
-}
-
-document.getElementById('addForm').addEventListener('submit', async e => {
+check();
+loginForm.addEventListener('submit', async e => {
   e.preventDefault();
-  const body = {
-    description: document.getElementById('desc').value,
-    departmentId: document.getElementById('deptSelect').value,
-    room: document.getElementById('room').value,
-    openedBy: document.getElementById('userSelect').value
-  };
-  await fetch('/api/tickets', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
-  e.target.reset();
-  loadTickets();
-});
-
-setLang(getLang());
-
-document.getElementById('deptForm').addEventListener('submit', async e => {
-  e.preventDefault();
-  await fetch('/api/departments', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({name: document.getElementById('newDept').value})});
-  e.target.reset();
-  loadTickets();
-});
-
-document.getElementById('staffForm').addEventListener('submit', async e => {
-  e.preventDefault();
-  const body = {
-    name: document.getElementById('newStaff').value,
-    departmentId: document.getElementById('staffDept').value
-  };
-  await fetch('/api/staff', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
-  e.target.reset();
-  loadTickets();
-});
-
-document.getElementById('closeForm').addEventListener('submit', async e => {
-  e.preventDefault();
-  const id = e.target.dataset.id;
-  const body = {
-    userId: document.getElementById('closeUser').value,
-    comment: document.getElementById('closeComment').value
-  };
-  await fetch(`/api/tickets/${id}/close`, {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
-  e.target.style.display = 'none';
-  e.target.reset();
-  loadTickets();
+  const body = {username: username.value, password: password.value};
+  const res = await fetch('/api/login', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body)});
+  if(res.ok){
+    const u = await res.json();
+    window.location.href = u.role === 'admin' ? '/admin.html' : '/app.html';
+  } else {
+    error.textContent = 'Invalid credentials';
+  }
 });
 </script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "ticketbox",
       "version": "1.0.0",
       "dependencies": {
+        "bcryptjs": "^3.0.2",
+        "cookie-parser": "^1.4.7",
         "express": "^4.18.2"
       }
     },
@@ -29,6 +31,15 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.2.tgz",
+      "integrity": "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
     },
     "node_modules/body-parser": {
       "version": "1.20.3",
@@ -117,6 +128,28 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "start": "node backend/index.js"
   },
   "dependencies": {
+    "bcryptjs": "^3.0.2",
+    "cookie-parser": "^1.4.7",
     "express": "^4.18.2"
   }
 }


### PR DESCRIPTION
## Summary
- add bcrypt and cookie-parser
- add user management with login endpoints
- protect app and admin pages on the backend
- create login page and separate admin panel
- remove admin features from the main UI and restore description textarea

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684af99777c8832fb3542d39bd82890a