### PR TITLE
Serve frontend with express and add Render guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,14 @@
 
 При обращении к `http://localhost:3000` откроется простая страница с формой добавления
 заявок и таблицей существующих. Данные хранятся в файле `backend/data/tickets.json`.
+
+## Deploy to Render
+
+1. Create a new **Web Service** in your Render account and connect this
+   repository.
+2. Set the build and start commands:
+   ```bash
+   npm install
+   npm start
+   ```
+3. Render will provide the `PORT` environment variable automatically.

--- a/backend/index.js
+++ b/backend/index.js
@@ -255,6 +255,11 @@ app.get('/api/rooms/:room', (req, res) => {
   res.json(tickets);
 });
 
+// fallback to index.html for any other route
+app.get('*', (req, res) => {
+  res.sendFile(path.join(FRONTEND, 'index.html'));
+});
+
 app.listen(PORT, () => {
   console.log(`Сервер запущен на http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- serve static files from `frontend` directory
- add catch-all route to return `index.html`
- document how to deploy on Render

## Testing
- `npm install`
- `npm start` (terminated after launch)

------
https://chatgpt.com/codex/tasks/task_e_684fe8268fbc832f82d9ec12cd1baec7