### PR TITLE
Improve mobile layout

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -2,19 +2,23 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title data-i18n="title">Hotel Sharon - TicketBox</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <div class="container">
-    <div class="header-logo">
-      <a href="https://sharon.co.il" target="_blank">
-        <img src="logo.png" alt="Hotel Sharon" />
-      </a>
-    </div>
-    <button id="langToggle"></button>
-    <button id="logout" data-i18n="logout"></button>
-    <a href="index.html">🏠 Home</a>
+      <header class="header">
+        <div class="header-logo">
+          <a href="https://sharon.co.il" target="_blank"><img src="logo.png" alt="Hotel Sharon" class="logo" /></a>
+          <h1 data-i18n="title">Hotel Sharon - TicketBox</h1>
+        </div>
+        <div class="header-buttons">
+          <button id="langToggle"></button>
+          <button id="logout" data-i18n="logout"></button>
+          <a href="index.html">🏠 Home</a>
+        </div>
+      </header>
 
 
   <h2 data-i18n="manageDepartments">Manage Departments</h2>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,19 +2,23 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title data-i18n="title">Hotel Sharon - TicketBox</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <div class="container">
-    <div class="header-logo">
-      <a href="https://sharon.co.il" target="_blank">
-        <img src="logo.png" alt="Hotel Sharon" />
-      </a>
-    </div>
-    <button id="langToggle"></button>
-    <button id="logout" data-i18n="logout"></button>
-    <a href="index.html">🏠 Home</a>
+    <header class="header">
+      <div class="header-logo">
+        <a href="https://sharon.co.il" target="_blank"><img src="logo.png" alt="Hotel Sharon" class="logo" /></a>
+        <h1 data-i18n="title">Hotel Sharon - TicketBox</h1>
+      </div>
+      <div class="header-buttons">
+        <button id="langToggle"></button>
+        <button id="logout" data-i18n="logout"></button>
+        <a href="index.html">🏠 Home</a>
+      </div>
+    </header>
 
   <div class="ticket-form">
     <h2 data-i18n="newTicket">New Ticket</h2>
@@ -28,6 +32,7 @@
   <h2 data-i18n="tickets">Tickets</h2>
   <label><span data-i18n="filterRoom">Filter by room</span>: <input type="text" id="filterRoom" /></label>
   <button onclick="loadTickets()" data-i18n="refresh">Refresh</button>
+    <div class="table-wrapper">
   <table id="tickets">
     <thead>
       <tr>
@@ -45,6 +50,7 @@
     </thead>
     <tbody></tbody>
   </table>
+    </div>
 
 
 

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -2,17 +2,21 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title data-i18n="title">Hotel Sharon - TicketBox</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <div class="container">
-    <div class="header-logo">
-      <a href="https://sharon.co.il" target="_blank">
-        <img src="logo.png" alt="Hotel Sharon" />
-      </a>
-    </div>
-    <button id="langToggle"></button>
+      <header class="header">
+        <div class="header-logo">
+          <a href="https://sharon.co.il" target="_blank"><img src="logo.png" alt="Hotel Sharon" class="logo" /></a>
+          <h1 data-i18n="title">Hotel Sharon - TicketBox</h1>
+        </div>
+        <div class="header-buttons">
+          <button id="langToggle"></button>
+        </div>
+      </header>
   <form id="loginForm">
     <input type="text" id="username" data-i18n-placeholder="login" required />
     <input type="password" id="password" data-i18n-placeholder="password" required />

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -11,36 +11,47 @@
   margin: 0 auto;
 }
 
-.header-logo {
-  text-align: center;
-  margin: 20px 0;
-}
-.header-logo img {
-  height: 80px;
-  object-fit: contain;
-}
 
 .header {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 20px;
-  margin: 20px 0;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1em;
+  margin: 1em 0;
 }
-
-.header .logo {
-  height: 60px;
+.header-logo {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
 }
-
+.header-logo img {
+  height: 5rem;
+  object-fit: contain;
+}
+.header-buttons {
+  display: flex;
+  gap: 0.5em;
+}
 .header-title h1,
 .header-title h3 {
   margin: 0;
   text-align: center;
 }
-
 @media (max-width: 600px) {
   .header {
     flex-direction: column;
+    align-items: center;
+  }
+  .header-logo {
+    flex-direction: column;
+  }
+  .header-logo img {
+    height: 3.5rem;
+  }
+  .header-buttons {
+    width: 100%;
+    justify-content: center;
   }
 }
 
@@ -48,6 +59,9 @@
   box-sizing: border-box;
 }
 
+button {
+  min-height: 2.75rem;
+}
 body {
   font-family: var(--font-stack);
   margin: 0;
@@ -87,9 +101,7 @@ h3 {
 h1 {
   font-size: 1.8em;
 }
-
 #langToggle {
-  float: right;
   background: none;
   border: none;
   cursor: pointer;
@@ -99,21 +111,22 @@ h1 {
 
 #langToggle:hover {
   color: var(--primary-color);
-}
-
 #logout {
-  float: right;
   margin-right: 0.5em;
   padding: 0.4em 0.8em;
   border: none;
   background-color: var(--primary-color);
   color: #fff;
-  border-radius: 4px;
+  border-radius: 0.25em;
   cursor: pointer;
 }
 
 #logout:hover {
   background-color: #005bb5;
+}
+
+#error {
+  color: var(--danger-color);
 }
 
 #error {
@@ -157,29 +170,29 @@ form button:hover {
 
 .ticket-form {
   background: #f9f9f9;
-  padding: 20px;
+  padding: 1.25rem;
   margin: 0 auto 30px;
   max-width: 500px;
-  border-radius: 10px;
+  border-radius: 0.625rem;
   box-shadow: 0 0 5px rgba(0,0,0,0.1);
   text-align: center;
 }
 .ticket-form textarea,
 .ticket-form input {
   width: 90%;
-  padding: 10px;
-  margin: 10px 0;
-  border-radius: 6px;
+  padding: 0.625rem;
+  margin: 0.625rem 0;
+  border-radius: 0.375rem;
   border: 1px solid #ccc;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 .ticket-form button {
   background-color: #005baa;
   color: white;
   border: none;
-  padding: 10px 20px;
-  border-radius: 6px;
-  font-size: 14px;
+  padding: 0.625rem 1.25rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
   cursor: pointer;
 }
 .ticket-form button:hover {
@@ -191,6 +204,11 @@ form button:hover {
     flex-direction: column;
     align-items: stretch;
   }
+  .ticket-form textarea,
+  .ticket-form input,
+  .ticket-form button {
+    width: 100%;
+  }
   #langToggle, #logout {
     float: none;
     align-self: flex-end;
@@ -198,6 +216,10 @@ form button:hover {
 }
 
 /* Table styles */
+.table-wrapper {
+  overflow-x: auto;
+}
+
 table {
   width: 100%;
   border-collapse: collapse;
@@ -211,16 +233,26 @@ thead th {
 
 th, td {
   border: 1px solid #ccc;
-  padding: 8px;
+  padding: 0.5em;
   text-align: start;
 }
-
+thead th {
+  white-space: nowrap;
+}
 tbody tr:nth-child(even) {
   background-color: #f9f9f9;
 }
 
 tbody tr:hover {
   background-color: #e6f2ff;
+}
+@media (max-width: 600px) {
+  th:nth-child(6),
+  td:nth-child(6),
+  th:nth-child(8),
+  td:nth-child(8) {
+    display: none;
+  }
 }
 
 .table-users, .table-staff {


### PR DESCRIPTION
## Summary
- add responsive header markup and table wrapper in HTML files
- tweak form layout for narrow screens
- overhaul header and table styles for mobile support
- ensure buttons have adequate touch size

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ff466f0f0832f9694ba018bd72063