### PR TITLE
Improve mobile layout for ticket table

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -295,8 +295,17 @@ async function loadTickets() {
     const closedBy = ticket.closedBy || '';
     const statusClass = ticket.closedAt ? 'status-closed' : 'status-open';
     const statusText = ticket.closedAt ? t('closedStatus') : t('openStatus');
-    tr.innerHTML = `<td>${ticket.id}</td><td>${ticket.description}</td><td>${ticket.room}</td><td>${dept ? dept.name : ''}</td><td>${openedBy}</td><td>${closedBy}</td><td>${opened}</td><td>${closed}</td><td class="${statusClass}">${statusText}</td>`;
+    tr.innerHTML = `<td data-label="${t('id')}">${ticket.id}</td>` +
+                  `<td data-label="${t('description')}">${ticket.description}</td>` +
+                  `<td data-label="${t('room')}">${ticket.room}</td>` +
+                  `<td data-label="${t('department')}">${dept ? dept.name : ''}</td>` +
+                  `<td data-label="${t('openedBy')}">${openedBy}</td>` +
+                  `<td data-label="${t('closedBy')}">${closedBy}</td>` +
+                  `<td data-label="${t('openedAt')}">${opened}</td>` +
+                  `<td data-label="${t('closedAt')}">${closed}</td>` +
+                  `<td data-label="${t('status')}" class="${statusClass}">${statusText}</td>`;
     const actionTd = document.createElement('td');
+    actionTd.setAttribute('data-label', t('actions'));
     if (!ticket.closedAt) {
       const btn = document.createElement('button');
       btn.textContent = t('close');

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -247,11 +247,41 @@ tbody tr:hover {
   background-color: #e6f2ff;
 }
 @media (max-width: 600px) {
-  th:nth-child(6),
-  td:nth-child(6),
-  th:nth-child(8),
-  td:nth-child(8) {
+  #tickets thead {
     display: none;
+  }
+  #tickets,
+  #tickets tbody,
+  #tickets tr,
+  #tickets td {
+    display: block;
+    width: 100%;
+  }
+  #tickets tr {
+    margin-bottom: 1rem;
+    border: 1px solid #ccc;
+    border-radius: 0.25rem;
+    padding: 0.5rem;
+  }
+  #tickets td {
+    border: none;
+    border-bottom: 1px solid #eee;
+    position: relative;
+    padding-left: 50%;
+    white-space: pre-wrap;
+  }
+  #tickets td:last-child {
+    border-bottom: 0;
+  }
+  #tickets td::before {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 45%;
+    padding-right: 0.5rem;
+    font-weight: bold;
+    white-space: nowrap;
+    content: attr(data-label);
   }
 }
 


### PR DESCRIPTION
## Summary
- display ticket rows as stacked cards on narrow screens
- add translation-aware labels to each table cell

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685000cae080832f8f6c506004cec9a4