### PR TITLE
Add responsive shared header

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -6,20 +6,11 @@
   <title data-i18n="title">Hotel Sharon - TicketBox</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
+  <script src="header.js"></script>
 </head>
-<body>
+  <body>
+  <div id="header"></div>
   <div class="container">
-      <div class="text-center my-3">
-        <a href="https://sharon.co.il" target="_blank">
-          <img src="logo.png" class="img-fluid" style="max-height:80px;" />
-        </a>
-        <h2 class="mt-2" data-i18n="title">Hotel Sharon - TicketBox</h2>
-      </div>
-      <div class="d-flex justify-content-center gap-2 mb-3">
-        <button id="langToggle" class="btn btn-sm btn-outline-secondary"></button>
-        <button id="logout" class="btn btn-sm btn-primary" data-i18n="logout"></button>
-        <a href="index.html" class="btn btn-sm btn-link">🏠 Home</a>
-      </div>
 
 
   <h2 data-i18n="manageDepartments">Manage Departments</h2>
@@ -184,7 +175,6 @@ function applyTranslations() {
   document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
     el.placeholder = t(el.dataset.i18nPlaceholder);
   });
-  document.getElementById('langToggle').textContent = currentLang === 'he' ? '🇬🇧 English' : '🇮🇱 עברית';
   document.documentElement.lang = currentLang;
   document.documentElement.dir = currentLang === 'he' ? 'rtl' : 'ltr';
 }
@@ -202,15 +192,6 @@ function getLang() {
   return navigator.language && navigator.language.startsWith('he') ? 'he' : 'en';
 }
 
-document.getElementById('langToggle').addEventListener('click', () => {
-  setLang(currentLang === 'en' ? 'he' : 'en');
-});
-document.getElementById('logout').addEventListener('click', async () => {
-  await fetch('/api/logout', {method:'POST', headers: authHeaders()});
-  localStorage.removeItem('user');
-  localStorage.removeItem('token');
-  window.location.href = '/login.html';
-});
 
 async function loadDepartmentsList() {
   const res = await fetch('/api/departments', { headers: authHeaders() });

--- a/frontend/guest.html
+++ b/frontend/guest.html
@@ -6,8 +6,10 @@
   <title>Report Issue</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
+  <script src="header.js"></script>
 </head>
-<body>
+  <body>
+  <div id="header"></div>
   <div class="container">
     <h2 class="text-center mt-3">Report an Issue</h2>
     <form id="guestForm" class="ticket-form">

--- a/frontend/header.html
+++ b/frontend/header.html
@@ -1,0 +1,28 @@
+<header>
+  <nav class="navbar navbar-expand-lg navbar-light bg-light">
+    <div class="container-fluid">
+      <a class="navbar-brand d-flex align-items-center" href="index.html">
+        <img src="logo.png" alt="Hotel Sharon" style="height:40px" class="me-2" />
+        <span>Hotel Sharon</span>
+      </a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav ms-auto text-center">
+          <li class="nav-item"><a class="nav-link" href="index.html" data-i18n="home">Home</a></li>
+          <li class="nav-item"><a class="nav-link" href="guest.html" data-i18n="report">Report</a></li>
+          <li class="nav-item admin-only d-none"><a class="nav-link" href="admin.html" data-i18n="admin">Admin</a></li>
+          <li class="nav-item"><a class="nav-link" id="loginLogout" href="login.html" data-i18n="login">Login</a></li>
+          <li class="nav-item ms-lg-2">
+            <select id="langSwitcher" class="form-select form-select-sm">
+              <option value="en">English</option>
+              <option value="he">עברית</option>
+              <option value="ru">Русский</option>
+            </select>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+</header>

--- a/frontend/header.js
+++ b/frontend/header.js
@@ -1,0 +1,69 @@
+(function(){
+  const translations = {
+    en: {home:'Home', report:'Report', admin:'Admin', login:'Login', logout:'Logout'},
+    he: {home:'\u05D3\u05E3 \u05D4\u05D1\u05D9\u05EA', report:'\u05E9\u05DC\u05D9\u05D7\u05EA \u05E4\u05E0\u05D9\u05D9\u05D4', admin:'\u05D0\u05D3\u05DE\u05D9\u05DF', login:'\u05DB\u05E0\u05D9\u05E1\u05D4', logout:'\u05D9\u05E6\u05D9\u05D0\u05D4'},
+    ru: {home:'\u0413\u043B\u0430\u0432\u043D\u0430\u044F', report:'\u041E\u0442\u043F\u0440\u0430\u0432\u0438\u0442\u044C \u0437\u0430\u044F\u0432\u043A\u0443', admin:'\u0410\u0434\u043C\u0438\u043D', login:'\u0412\u0445\u043E\u0434', logout:'\u0412\u044B\u0445\u043E\u0434'}
+  };
+  let lang = localStorage.getItem('lang') || (navigator.language && navigator.language.startsWith('he') ? 'he' : 'en');
+
+  function t(key){
+    return translations[lang][key] || key;
+  }
+
+  function authHeaders(){
+    const token = localStorage.getItem('token');
+    return token ? { 'Authorization': 'Bearer ' + token } : {};
+  }
+
+  function apply(){
+    document.querySelectorAll('#header [data-i18n]').forEach(el => {
+      const k = el.getAttribute('data-i18n');
+      if(translations[lang][k]) el.textContent = translations[lang][k];
+    });
+    const sel = document.getElementById('langSwitcher');
+    if(sel) sel.value = lang;
+  }
+
+  function updateLang(newLang){
+    lang = newLang;
+    localStorage.setItem('lang', lang);
+    apply();
+    if(window.setLang) window.setLang(lang);
+  }
+
+  async function setupLogin(){
+    const userStr = localStorage.getItem('user');
+    const link = document.getElementById('loginLogout');
+    const adminLink = document.querySelector('.admin-only');
+    if(userStr){
+      const user = JSON.parse(userStr);
+      link.textContent = t('logout');
+      link.href = '#';
+      link.addEventListener('click', async e => {
+        e.preventDefault();
+        await fetch('/api/logout', {method:'POST', headers: authHeaders()}).catch(()=>{});
+        localStorage.removeItem('user');
+        localStorage.removeItem('token');
+        window.location.href = '/login.html';
+      });
+      if(user.role === 'admin' && adminLink) adminLink.classList.remove('d-none');
+    } else {
+      link.textContent = t('login');
+      link.href = 'login.html';
+      if(adminLink) adminLink.classList.add('d-none');
+    }
+  }
+
+  function init(){
+    const container = document.getElementById('header');
+    if(!container) return;
+    fetch('header.html').then(r=>r.text()).then(html=>{
+      container.innerHTML = html;
+      document.getElementById('langSwitcher').addEventListener('change', e=>updateLang(e.target.value));
+      apply();
+      setupLogin();
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,21 +5,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title data-i18n="title">Hotel Sharon - TicketBox</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="style.css" />
+<link rel="stylesheet" href="style.css" />
+  <script src="header.js"></script>
 </head>
-<body>
+  <body>
+  <div id="header"></div>
   <div class="container">
-    <div class="text-center my-3">
-      <a href="https://sharon.co.il" target="_blank">
-        <img src="logo.png" class="img-fluid" style="max-height:80px;" />
-      </a>
-      <h2 class="mt-2" data-i18n="title">Hotel Sharon - TicketBox</h2>
-    </div>
-    <div class="d-flex justify-content-center gap-2 mb-3">
-      <button id="langToggle" class="btn btn-sm btn-outline-secondary"></button>
-      <button id="logout" class="btn btn-sm btn-primary" data-i18n="logout"></button>
-      <a href="index.html" class="btn btn-sm btn-link">🏠 Home</a>
-    </div>
 
   <div class="ticket-form">
     <h2 data-i18n="newTicket">New Ticket</h2>
@@ -82,12 +73,6 @@ async function requireLogin(){
     return;
   }
   currentUser = JSON.parse(stored);
-  if(currentUser.role === 'admin'){
-    const a = document.createElement('a');
-    a.href = '/admin.html';
-    a.textContent = 'Admin';
-    document.body.prepend(a);
-  }
 }
 requireLogin();
 const translations = {
@@ -161,7 +146,6 @@ function applyTranslations() {
   document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
     el.placeholder = t(el.dataset.i18nPlaceholder);
   });
-  document.getElementById('langToggle').textContent = currentLang === 'he' ? '🇬🇧 English' : '🇮🇱 עברית';
   document.documentElement.lang = currentLang;
   document.documentElement.dir = currentLang === 'he' ? 'rtl' : 'ltr';
 }
@@ -190,15 +174,6 @@ function formatDate(str) {
   return `${day}/${month}/${year} ${hours}:${minutes}`;
 }
 
-document.getElementById('langToggle').addEventListener('click', () => {
-  setLang(currentLang === 'en' ? 'he' : 'en');
-});
-document.getElementById('logout').addEventListener('click', async () => {
-  await fetch('/api/logout', {method:'POST', headers: authHeaders()});
-  localStorage.removeItem('user');
-  localStorage.removeItem('token');
-  window.location.href = '/login.html';
-});
 
 async function loadDepartmentsList() {
   const res = await fetch('/api/departments', { headers: authHeaders() });

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -6,18 +6,11 @@
   <title data-i18n="title">Hotel Sharon - TicketBox</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
+  <script src="header.js"></script>
 </head>
-<body>
+  <body>
+  <div id="header"></div>
   <div class="container">
-      <div class="text-center my-3">
-        <a href="https://sharon.co.il" target="_blank">
-          <img src="logo.png" class="img-fluid" style="max-height:80px;" />
-        </a>
-        <h2 class="mt-2" data-i18n="title">Hotel Sharon - TicketBox</h2>
-      </div>
-      <div class="d-flex justify-content-center gap-2 mb-3">
-        <button id="langToggle" class="btn btn-sm btn-outline-secondary"></button>
-      </div>
   <form id="loginForm" class="container mt-3">
     <input type="text" id="username" data-i18n-placeholder="login" class="form-control mb-2" required />
     <input type="password" id="password" data-i18n-placeholder="password" class="form-control mb-2" required />
@@ -66,7 +59,6 @@ function applyTranslations() {
   document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
     el.placeholder = t(el.dataset.i18nPlaceholder);
   });
-  document.getElementById('langToggle').textContent = currentLang === 'he' ? '🇬🇧 English' : '🇮🇱 עברית';
   document.documentElement.lang = currentLang;
   document.documentElement.dir = currentLang === 'he' ? 'rtl' : 'ltr';
 }
@@ -83,9 +75,6 @@ function getLang() {
   return navigator.language && navigator.language.startsWith('he') ? 'he' : 'en';
 }
 
-document.getElementById('langToggle').addEventListener('click', () => {
-  setLang(currentLang === 'en' ? 'he' : 'en');
-});
 setLang(getLang());
 check();
 async function check() {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -343,3 +343,14 @@ th.sorted-desc::after {
 tbody tr.divider td {
   border-top: 2px solid #ccc;
 }
+
+/* Navbar adjustments */
+.navbar-brand img {
+  height: 40px;
+}
+@media (max-width: 600px) {
+  .navbar-nav {
+    flex-direction: column;
+    align-items: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add shared header component with language switcher
- support login/logout actions in new `header.js`
- update pages to load the new header
- tweak styling for navbar

## Testing
- `npm start` *(fails: Identifier 'PORT' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_685022e26b3c832fb56e6a96a54e5781