### PR TITLE
Delay server start until MongoDB connection

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -5,9 +5,24 @@ const fs = require('fs');
 const crypto = require('crypto');
 const bcrypt = require('bcryptjs');
 const multer = require('multer');
+const mongoose = require('mongoose');
 const { Ticket, User, Department, Photo } = require('./models');
 
 const PORT = process.env.PORT || 3000;
+
+if (!process.env.MONGODB_URI) {
+  throw new Error('MONGODB_URI is not defined');
+}
+
+mongoose.connect(process.env.MONGODB_URI, {
+  useNewUrlParser: true,
+  useUnifiedTopology: true
+});
+
+mongoose.connection.on('error', err => {
+  console.error('MongoDB connection error:', err);
+  process.exit(1);
+});
 
 const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, 'data');
 if (!fs.existsSync(DATA_DIR)) {
@@ -260,6 +275,9 @@ app.get('*', (req, res) => {
   res.sendFile(path.join(FRONTEND, 'index.html'));
 });
 
-app.listen(PORT, () => {
-  console.log(`Сервер запущен на порту ${PORT}`);
+mongoose.connection.once('open', () => {
+  console.log('MongoDB connected');
+  app.listen(PORT, () => {
+    console.log(`Server running on port ${PORT}`);
+  });
 });

--- a/backend/models.js
+++ b/backend/models.js
@@ -1,21 +1,4 @@
-require('dotenv').config();
 const mongoose = require('mongoose');
-
-const MONGO_URI = process.env.MONGODB_URI;
-if(!MONGO_URI) {
-  throw new Error('MONGODB_URI is not defined');
-}
-
-mongoose.connect(MONGO_URI, {
-  useNewUrlParser: true,
-  useUnifiedTopology: true,
-  dbName: 'ticketbox',
-});
-
-mongoose.connection.once('open', () => {
-  console.log('✅ Connected to MongoDB');
-});
-mongoose.connection.on('error', console.error);
 
 const DepartmentSchema = new mongoose.Schema({
   name: { type: String, required: true }


### PR DESCRIPTION
## Summary
- connect to MongoDB in `backend/index.js`
- exit on connection error and start server only after `open`
- remove connection logic from `backend/models.js`

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68502d8f3858832fa2e095df18069350