### PR TITLE
Fix login redirect loop and persist auth

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -79,12 +79,21 @@ function authHeaders(){
 }
 async function requireLogin(){
   const stored = localStorage.getItem('user');
-  if(!stored){
+  let u = null;
+  if(stored){
+    u = JSON.parse(stored);
+  } else {
+    const res = await fetch('/api/me');
+    if(res.ok){
+      u = await res.json();
+      localStorage.setItem('user', JSON.stringify(u));
+    }
+  }
+  if(!u){
     window.location.href = '/login.html';
     return;
   }
-  const u = JSON.parse(stored);
-  if(u.role !== 'admin') { window.location.href = '/index.html'; return; }
+  if(u.role !== 'admin'){ window.location.href = '/index.html'; return; }
   currentUser = u;
 }
 requireLogin();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -69,11 +69,17 @@ function authHeaders(){
 }
 async function requireLogin(){
   const stored = localStorage.getItem('user');
-  if(!stored){
-    window.location.href = '/login.html';
+  if(stored){
+    currentUser = JSON.parse(stored);
     return;
   }
-  currentUser = JSON.parse(stored);
+  const res = await fetch('/api/me');
+  if(res.ok){
+    currentUser = await res.json();
+    localStorage.setItem('user', JSON.stringify(currentUser));
+    return;
+  }
+  window.location.href = '/login.html';
 }
 requireLogin();
 const translations = {


### PR DESCRIPTION
## Summary
- look for JWT token in cookies on the server
- set and clear cookie during login/logout
- fallback to `/api/me` when user info is missing on protected pages

## Testing
- `npm install`
- `npm start` *(fails: MONGODB_URI is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68504b9d3da8832fafd585e605048d4b