### PR TITLE
Implement guest defaults and photo modal

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -200,7 +200,8 @@ app.post('/api/public-ticket', upload.single('photo'), async (req, res) => {
     description,
     room,
     departmentId: null,
-    createdBy: 'Guest'
+    openedBy: 'guest',
+    openedAt: new Date()
   });
   if (req.file) {
     await Photo.create({
@@ -225,7 +226,8 @@ app.post('/api/tickets', async (req, res) => {
     description,
     room,
     departmentId: body.departmentId || null,
-    createdBy: req.user ? req.user.username : body.createdBy || ''
+    openedBy: req.user ? req.user.username : 'guest',
+    openedAt: new Date()
   });
   console.log('Saved to DB');
   res.json(ticket);
@@ -238,7 +240,9 @@ app.post('/api/tickets/:id/close', async (req, res) => {
   if (!ticket.isClosed) {
     ticket.isClosed = true;
     ticket.closedAt = new Date();
+    ticket.closedBy = req.user ? req.user.username : '';
     await ticket.save();
+    await Photo.deleteMany({ ticketId: ticket._id });
     console.log('Saved to DB');
   }
   res.json(ticket);

--- a/backend/models.js
+++ b/backend/models.js
@@ -18,8 +18,9 @@ const TicketSchema = new mongoose.Schema({
   description: String,
   room: String,
   departmentId: { type: mongoose.Schema.Types.ObjectId, ref: 'Department' },
-  createdBy: String,
-  createdAt: { type: Date, default: Date.now },
+  openedBy: { type: String, default: 'guest' },
+  openedAt: { type: Date, default: Date.now },
+  closedBy: String,
   closedAt: Date,
   isClosed: { type: Boolean, default: false }
 });

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -305,7 +305,7 @@ async function loadTickets() {
                   `<td data-label="${t('description')}">${ticket.description}</td>` +
                   `<td data-label="${t('room')}">${ticket.room}</td>` +
                   `<td data-label="${t('department')}">${dept ? dept.name : ''}</td>` +
-                  `<td data-label="${t('photo')}">${ticket.photoUrl ? '<img src="' + ticket.photoUrl + '" style="max-width:60px">' : ''}</td>` +
+                  `<td data-label="${t('photo')}">${ticket.photoUrl ? '<img src="' + ticket.photoUrl + '" class="photo-thumb" style="max-width:60px">' : ''}</td>` +
                   `<td data-label="${t('openedBy')}">${openedBy}</td>` +
                   `<td data-label="${t('closedBy')}">${closedBy}</td>` +
                   `<td data-label="${t('openedAt')}">${opened}</td>` +
@@ -334,7 +334,7 @@ async function loadTickets() {
         `<p><strong>${t('id')}:</strong> ${ticket.id}</p>` +
         `<p><strong>${t('description')}:</strong> ${ticket.description}</p>` +
         `<p><strong>${t('room')}:</strong> ${ticket.room}</p>` +
-        (ticket.photoUrl ? `<p><img src="${ticket.photoUrl}" style="max-width:100%"></p>` : '') +
+        (ticket.photoUrl ? `<p><img src="${ticket.photoUrl}" class="photo-thumb" style="max-width:100%"></p>` : '') +
         `<p><strong>${t('openedBy')}:</strong> ${openedBy}</p>` +
         `<p><strong>${t('closedBy')}:</strong> ${closedBy || '-'}</p>` +
         `<p><strong>${t('status')}:</strong> <span class="badge ${ticket.closedAt ? 'bg-secondary' : 'bg-success'}">${statusText}</span></p>`;
@@ -411,7 +411,22 @@ if (deptForm) {
 }
 
 // No staff management or close form required
+document.body.addEventListener('click', e => {
+  if (e.target.classList.contains('photo-thumb')) {
+    document.getElementById('modalImage').src = e.target.src;
+    bootstrap.Modal.getOrCreateInstance(document.getElementById('photoModal')).show();
+  }
+});
 </script>
+  </div>
+  <div class="modal fade" id="photoModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+      <div class="modal-content">
+        <div class="modal-body p-0">
+          <img id="modalImage" src="" class="img-fluid w-100" alt="photo">
+        </div>
+      </div>
+    </div>
   </div>
 </body>
 </html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -66,24 +66,8 @@ body {
   font-family: var(--font-stack);
   margin: 0;
   padding: 1em;
-  background-color: #f5f5f5;
+  background-color: #fff;
   color: #222;
-}
-
-@media (prefers-color-scheme: dark) {
-  body {
-    background-color: #1a1a1a;
-    color: #e4e4e4;
-  }
-  table, th, td {
-    border-color: #555;
-  }
-  thead th {
-    background-color: #333;
-  }
-  tbody tr:nth-child(even) {
-    background-color: #2a2a2a;
-  }
 }
 
 h1, h2 {
@@ -299,6 +283,17 @@ tbody tr:hover {
   font-weight: bold;
 }
 
+.photo-thumb {
+  transition: transform 0.2s;
+  cursor: pointer;
+}
+
+.photo-thumb:hover {
+  transform: scale(2);
+  z-index: 10;
+  position: relative;
+}
+
 /* Lists and admin sections */
 ul {
   list-style: none;
@@ -329,12 +324,6 @@ ul li button {
   background-color: #f9f9f9;
 }
 
-@media (prefers-color-scheme: dark) {
-  .panel {
-    background-color: #2a2a2a;
-    border-color: #444;
-  }
-}
 
 /* Sorting */
 th.sortable {


### PR DESCRIPTION
## Summary
- auto-fill `openedBy` and `openedAt` on ticket creation
- store closing user, remove photo on close
- show ticket photos with zoom and modal viewer
- lighten UI by removing dark theme

## Testing
- `npm install --silent`
- `npm start` *(fails: MONGODB_URI is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685056ef8ec8832f976d51ba6f2e9089