### PR TITLE
Disable autocomplete on internal forms

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -19,9 +19,9 @@
   <h2 data-i18n="manageDepartments">Manage Departments</h2>
   <div class="panel form-section">
     <h3>Add New Department</h3>
-    <form id="deptForm" class="row g-2">
+    <form id="deptForm" class="row g-2" autocomplete="off">
       <div class="col">
-        <input type="text" id="newDept" class="form-control" required />
+        <input type="text" id="newDept" class="form-control" autocomplete="off" required />
       </div>
       <div class="col-auto">
         <button type="submit" class="btn btn-primary" data-i18n="add">Add</button>
@@ -33,12 +33,12 @@
   <h2 data-i18n="manageUsers">Manage Users</h2>
   <div class="panel form-section">
     <h3>Add User (Login Access)</h3>
-    <form id="userForm" class="row g-2 align-items-end">
+    <form id="userForm" class="row g-2 align-items-end" autocomplete="off">
       <div class="col-md-3">
-        <input type="text" id="newUsername" data-i18n-placeholder="login" class="form-control" required />
+        <input type="text" id="newUsername" data-i18n-placeholder="login" class="form-control" autocomplete="off" required />
       </div>
       <div class="col-md-3">
-        <input type="password" id="newPassword" data-i18n-placeholder="password" class="form-control" required />
+        <input type="password" id="newPassword" data-i18n-placeholder="password" class="form-control" autocomplete="new-password" required />
       </div>
       <div class="col-md-3">
         <select id="userDept" class="form-select"></select>
@@ -66,12 +66,12 @@
   <h2 data-i18n="changePassword">Change Password</h2>
   <div class="panel form-section">
     <h3>Change Password</h3>
-    <form id="passwordForm" class="row g-2">
+    <form id="passwordForm" class="row g-2" autocomplete="off">
       <div class="col-md-4">
         <select id="passwordUser" class="form-select"></select>
       </div>
       <div class="col-md-4">
-        <input type="password" id="adminPassword" class="form-control" placeholder="New Password" required />
+        <input type="password" id="adminPassword" class="form-control" placeholder="New Password" autocomplete="new-password" required />
       </div>
       <div class="col-md-4">
         <button type="submit" class="btn btn-primary w-100" data-i18n="change">Change</button>

--- a/frontend/guest.html
+++ b/frontend/guest.html
@@ -15,9 +15,9 @@
   <div id="header"></div>
   <div class="container">
     <h2 class="text-center mt-3" data-i18n="heading">Report an Issue</h2>
-    <form id="guestForm" class="ticket-form form-section">
-      <input type="text" id="room" class="form-control mb-2" data-i18n-placeholder="room" required />
-      <textarea id="desc" class="form-control mb-2" data-i18n-placeholder="description"></textarea>
+    <form id="guestForm" class="ticket-form form-section" autocomplete="off">
+      <input type="text" id="room" class="form-control mb-2" data-i18n-placeholder="room" autocomplete="off" required />
+      <textarea id="desc" class="form-control mb-2" data-i18n-placeholder="description" autocomplete="off"></textarea>
       <input type="file" id="photo" class="form-control mb-2" accept="image/*" />
       <button type="submit" class="btn btn-primary w-100" data-i18n="submit">Submit</button>
     </form>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,13 +17,13 @@
 
   <div class="ticket-form form-section">
     <h2 data-i18n="newTicket">New Ticket</h2>
-    <form id="addForm" class="container mt-3">
+    <form id="addForm" class="container mt-3" autocomplete="off">
       <div class="row g-2">
         <div class="col-12 col-sm-6">
-          <textarea id="desc" data-i18n-placeholder="description" class="form-control" required></textarea>
+          <textarea id="desc" data-i18n-placeholder="description" class="form-control" autocomplete="off" required></textarea>
         </div>
         <div class="col-12 col-sm-4">
-          <input type="text" id="room" data-i18n-placeholder="room" class="form-control" required />
+          <input type="text" id="room" data-i18n-placeholder="room" class="form-control" autocomplete="off" required />
         </div>
         <div class="col-12 col-sm-2">
           <button type="submit" class="btn btn-primary w-100" data-i18n="addTicket">Add Ticket</button>
@@ -33,7 +33,7 @@
   </div>
 
   <h2 data-i18n="tickets">Tickets</h2>
-  <label><span data-i18n="filterRoom">Filter by room</span>: <input type="text" id="filterRoom" /></label>
+  <label><span data-i18n="filterRoom">Filter by room</span>: <input type="text" id="filterRoom" autocomplete="off" /></label>
   <button onclick="loadTickets()" data-i18n="refresh" class="btn btn-secondary mb-2">Refresh</button>
   <div id="ticketCards" class="d-md-none"></div>
   <div class="d-none d-md-block">

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -14,9 +14,9 @@
   <body>
   <div id="header"></div>
   <div class="container">
-  <form id="loginForm" class="container mt-3 form-section">
-    <input type="text" id="username" data-i18n-placeholder="login" class="form-control mb-2" required />
-    <input type="password" id="password" data-i18n-placeholder="password" class="form-control mb-2" required />
+  <form id="loginForm" class="container mt-3 form-section" autocomplete="on">
+    <input type="text" id="username" name="username" data-i18n-placeholder="login" class="form-control mb-2" autocomplete="username" autofocus required />
+    <input type="password" id="password" name="password" data-i18n-placeholder="password" class="form-control mb-2" autocomplete="current-password" required />
     <button type="submit" class="btn btn-primary w-100" data-i18n="signIn">Login</button>
   </form>
   <div id="error"></div>


### PR DESCRIPTION
## Summary
- allow username/password autofill on the login page
- disable autocomplete and suggestions on other forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850f4f97a70832fa240d9ae64ca9b99