### PR TITLE
Improve mobile logo responsiveness

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -377,8 +377,16 @@ tbody tr.divider td {
   width: 100%;
   max-width: 150px;
   height: auto;
+  max-height: 120px;
   display: block;
   margin: 0 auto;
+}
+
+@media (max-width: 768px) {
+  .logo {
+    max-height: 80px;
+    margin-bottom: 10px;
+  }
 }
 
 .logo-container {


### PR DESCRIPTION
## Summary
- adjust logo CSS to limit height on desktop and mobile

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6852cbc86c58832f8548bdba19c70417