### PR TITLE
Fix responsive logo scaling

### DIFF
--- a/frontend/header.html
+++ b/frontend/header.html
@@ -1,7 +1,7 @@
 <header class="mb-3">
   <div class="container">
     <div class="logo text-center my-3">
-      <img src="logo.png" alt="Hotel Logo">
+      <img src="logo.png" alt="Logo" class="img-fluid logo-img">
     </div>
     <nav class="navbar navbar-expand-lg navbar-light bg-light mt-2">
       <div class="container-fluid">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -373,18 +373,15 @@ tbody tr.divider td {
   transform: rotate(90deg);
 }
 
-.logo img {
+.logo-img {
   max-width: 100%;
   height: auto;
   max-height: 100px;
-  display: block;
-  margin: 0 auto;
 }
 
 @media (max-width: 768px) {
-  .logo img {
+  .logo-img {
     max-height: 70px;
-    margin-bottom: 10px;
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust header markup to use `img-fluid logo-img`
- add `.logo-img` class in CSS for scaling

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852f132a728832f80d176b9b0d0b16d