### PR TITLE
Добавлена загрузка изображений для новостей

### DIFF
--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -99,13 +99,14 @@
 
   <h2 data-i18n="manageNews">News</h2>
   <div class="panel form-section">
-    <form id="newsForm" class="mb-3">
+    <form id="newsForm" class="mb-3" enctype="multipart/form-data">
       <div class="mb-2">
         <input type="text" id="newsTitle" class="form-control" data-i18n-placeholder="newsTitle" required />
       </div>
       <div class="mb-2">
         <textarea id="newsContent" class="form-control" rows="3" data-i18n-placeholder="newsContent" required></textarea>
       </div>
+      <input type="file" id="newsImage" name="image" accept="image/*" class="form-control mb-3">
       <button type="submit" class="btn btn-primary" data-i18n="publish">Publish</button>
     </form>
     <ul id="newsList" class="list-group"></ul>
@@ -498,6 +499,12 @@ function renderNewsList() {
     const div = document.createElement('div');
     div.className = 'me-2';
     div.innerHTML = `<strong>${n.title}</strong><div>${n.content}</div>`;
+    if(n.imageUrl){
+      const img = document.createElement('img');
+      img.src = n.imageUrl;
+      img.className = 'img-fluid rounded mb-2';
+      div.appendChild(img);
+    }
     li.appendChild(div);
     const del = document.createElement('button');
     del.className = 'btn btn-sm btn-danger';
@@ -517,6 +524,8 @@ document.getElementById('newsForm').addEventListener('submit', async e => {
   const fd = new FormData();
   fd.append('title', document.getElementById('newsTitle').value.trim());
   fd.append('content', document.getElementById('newsContent').value.trim());
+  const file = document.getElementById('newsImage').files[0];
+  if(file) fd.append('image', file);
   const res = await fetch('/api/news', { method: 'POST', headers: authHeaders(), body: fd });
   if (res.ok) {
     e.target.reset();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -28,12 +28,13 @@ async function loadNews(){
     div.className = 'news-card';
     const date = new Date(n.createdAt).toLocaleDateString();
     div.innerHTML = `<h3>${n.title}</h3><small>${date}</small><p>${n.content}</p>`;
-    if(n.imageUrl){
-      const img = document.createElement('img');
-      img.src = n.imageUrl;
-      img.className = 'img-fluid';
-      div.appendChild(img);
-    }
+      if(n.imageUrl){
+        const img = document.createElement('img');
+        img.src = n.imageUrl;
+        img.alt = 'News Image';
+        img.className = 'img-fluid rounded mb-3';
+        div.appendChild(img);
+      }
     container.appendChild(div);
   });
 }


### PR DESCRIPTION
## Summary
- allow uploading news images to server
- show uploaded images in admin/news lists
- store images under `/uploads/news`
- display images responsively on the main page

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68531257b664832fb0d6ee8ad9ce5731