### PR TITLE
Add search page and show today's closed tickets

### DIFF
--- a/frontend/header.html
+++ b/frontend/header.html
@@ -15,6 +15,7 @@
           <li class="nav-item"><a class="nav-link" href="guest.html" data-i18n="report">Report</a></li>
           <li class="nav-item admin-only d-none"><a class="nav-link" href="admin.html" data-i18n="admin">Admin</a></li>
           <li class="nav-item users-only d-none"><a class="nav-link" href="users.html" data-i18n="manageUsers">Users</a></li>
+          <li class="nav-item users-only d-none"><a class="nav-link" href="search.html" data-i18n="search">Search</a></li>
           <li class="nav-item"><a class="nav-link" id="loginLogout" href="login.html" data-i18n="login">Login</a></li>
           <li class="nav-item ms-lg-2">
             <select id="langSwitcher" class="form-select form-select-sm">

--- a/frontend/header.js
+++ b/frontend/header.js
@@ -1,8 +1,8 @@
 (function(){
   const translations = {
-    en: {home:'Home', faults:'Faults', report:'Report', admin:'Admin', manageUsers:'Users', login:'Login', logout:'Logout'},
-    he: {home:'\u05D3\u05E3 \u05D4\u05D1\u05D9\u05EA', faults:'\u05EA\u05E7\u05DC\u05D5\u05EA', report:'\u05E9\u05DC\u05D9\u05D7\u05EA \u05E4\u05E0\u05D9\u05D9\u05D4', admin:'\u05D0\u05D3\u05DE\u05D9\u05DF', manageUsers:'\u05DE\u05E9\u05EA\u05DE\u05E9\u05D9\u05DD', login:'\u05DB\u05E0\u05D9\u05E1\u05D4', logout:'\u05D9\u05E6\u05D9\u05D0\u05D4'},
-    ru: {home:'\u0413\u043B\u0430\u0432\u043D\u0430\u044F', faults:'\u041F\u043E\u043B\u043E\u043C\u043A\u0438', report:'\u041E\u0442\u043F\u0440\u0430\u0432\u0438\u0442\u044C \u0437\u0430\u044F\u0432\u043A\u0443', admin:'\u0410\u0434\u043C\u0438\u043D', manageUsers:'\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u0438', login:'\u0412\u0445\u043E\u0434', logout:'\u0412\u044B\u0445\u043E\u0434'}
+    en: {home:'Home', faults:'Faults', report:'Report', admin:'Admin', manageUsers:'Users', search:'Search', login:'Login', logout:'Logout'},
+    he: {home:'\u05D3\u05E3 \u05D4\u05D1\u05D9\u05EA', faults:'\u05EA\u05E7\u05DC\u05D5\u05EA', report:'\u05E9\u05DC\u05D9\u05D7\u05EA \u05E4\u05E0\u05D9\u05D9\u05D4', admin:'\u05D0\u05D3\u05DE\u05D9\u05DF', manageUsers:'\u05DE\u05E9\u05EA\u05DE\u05E9\u05D9\u05DD', search:'\u05D7\u05D9\u05E4\u05D5\u05E9', login:'\u05DB\u05E0\u05D9\u05E1\u05D4', logout:'\u05D9\u05E6\u05D9\u05D0\u05D4'},
+    ru: {home:'\u0413\u043B\u0430\u0432\u043D\u0430\u044F', faults:'\u041F\u043E\u043B\u043E\u043C\u043A\u0438', report:'\u041E\u0442\u043F\u0440\u0430\u0432\u0438\u0442\u044C \u0437\u0430\u044F\u0432\u043A\u0443', admin:'\u0410\u0434\u043C\u0438\u043D', manageUsers:'\u041F\u043E\u043B\u044C\u0437\u043E\u0432\u0430\u0442\u0435\u043B\u0438', search:'\u041F\u043E\u0438\u0441\u043A', login:'\u0412\u0445\u043E\u0434', logout:'\u0412\u044B\u0445\u043E\u0434'}
   };
   let lang = localStorage.getItem('lang') || (navigator.language && navigator.language.startsWith('he') ? 'he' : 'en');
 
@@ -43,7 +43,7 @@
     const userStr = localStorage.getItem('user');
     const link = document.getElementById('loginLogout');
     const adminLink = document.querySelector('.admin-only');
-    const usersLink = document.querySelector('.users-only');
+    const usersLinks = document.querySelectorAll('.users-only');
     const faultLink = document.getElementById('faultLink');
     if(userStr){
       const user = JSON.parse(userStr);
@@ -57,13 +57,13 @@
         window.location.href = '/login.html';
       });
       if(user.role === 'admin' && adminLink) adminLink.classList.remove('d-none');
-      if(usersLink && (user.role === 'admin' || user.role === 'superuser')) usersLink.classList.remove('d-none');
+      if(usersLinks.length && (user.role === 'admin' || user.role === 'superuser')) usersLinks.forEach(l=>l.classList.remove('d-none'));
       if(faultLink) faultLink.classList.remove('d-none');
     } else {
       link.textContent = t('login');
       link.href = 'login.html';
       if(adminLink) adminLink.classList.add('d-none');
-      if(usersLink) usersLink.classList.add('d-none');
+      if(usersLinks.length) usersLinks.forEach(l=>l.classList.add('d-none'));
       if(faultLink) faultLink.classList.add('d-none');
     }
   }

--- a/frontend/search.html
+++ b/frontend/search.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Search Tickets</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="style.css" />
+  <link rel="icon" type="image/png" href="logo.png" />
+  <script src="header.js"></script>
+  <script src="utils/notifications.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</head>
+<body>
+<div id="header"></div>
+<div class="container mt-3">
+  <h2>Search Tickets</h2>
+  <form id="searchForm" class="row g-2 mb-3">
+    <div class="col-md-2"><input type="date" id="openFrom" class="form-control" placeholder="Open from"></div>
+    <div class="col-md-2"><input type="date" id="openTo" class="form-control" placeholder="Open to"></div>
+    <div class="col-md-2"><input type="date" id="closeFrom" class="form-control" placeholder="Close from"></div>
+    <div class="col-md-2"><input type="date" id="closeTo" class="form-control" placeholder="Close to"></div>
+    <div class="col-md-2"><input type="text" id="room" class="form-control" placeholder="Room"></div>
+    <div class="col-md-2">
+      <select id="status" class="form-select">
+        <option value="">All</option>
+        <option value="open">Open</option>
+        <option value="closed">Closed</option>
+        <option value="inprogress">In Process</option>
+      </select>
+    </div>
+    <div class="col-md-2"><input type="text" id="openedBy" class="form-control" placeholder="Opened by"></div>
+    <div class="col-md-2"><input type="text" id="closedBy" class="form-control" placeholder="Closed by"></div>
+    <div class="col-md-2"><select id="department" class="form-select"></select></div>
+    <div class="col-md-2"><input type="text" id="keyword" class="form-control" placeholder="Keyword"></div>
+    <div class="col-md-2"><button type="submit" class="btn btn-primary w-100">Search</button></div>
+  </form>
+  <div class="table-responsive">
+    <table id="results" class="table table-bordered table-sm">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Description</th>
+          <th>Room</th>
+          <th>Department</th>
+          <th>Opened by</th>
+          <th>Closed by</th>
+          <th>Opened at</th>
+          <th>Closed at</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+</div>
+<script>
+let currentUser = null;
+let departments = [];
+function authHeaders(){
+  const token = localStorage.getItem('token');
+  return token ? { 'Authorization': 'Bearer ' + token } : {};
+}
+async function requireLogin(){
+  const stored = localStorage.getItem('user');
+  if(stored){ const u = JSON.parse(stored); if(u.role==='admin'||u.role==='superuser'){ currentUser=u; return; } }
+  const res = await fetch('/api/me');
+  if(res.ok){ const u = await res.json(); localStorage.setItem('user', JSON.stringify(u)); if(u.role==='admin'||u.role==='superuser'){ currentUser=u; return; }}
+  localStorage.removeItem('user');
+  localStorage.removeItem('token');
+  window.location.href = '/login.html';
+}
+requireLogin();
+async function loadDepartments(){
+  const res = await fetch('/api/departments', {headers: authHeaders()});
+  departments = await res.json();
+  const sel = document.getElementById('department');
+  sel.innerHTML = '<option value="">All</option>';
+  departments.forEach(d=>{ const o=document.createElement('option'); o.value=d.id; o.textContent=d.name; sel.appendChild(o); });
+}
+function formatDate(str){
+  if(!str) return '';
+  const d = new Date(str);
+  return d.toLocaleString();
+}
+async function searchTickets(){
+  const params = new URLSearchParams();
+  const of=document.getElementById('openFrom').value; if(of) params.set('openFrom', of);
+  const ot=document.getElementById('openTo').value; if(ot) params.set('openTo', ot);
+  const cf=document.getElementById('closeFrom').value; if(cf) params.set('closeFrom', cf);
+  const ct=document.getElementById('closeTo').value; if(ct) params.set('closeTo', ct);
+  const room=document.getElementById('room').value.trim(); if(room) params.set('room', room);
+  const status=document.getElementById('status').value; if(status) params.set('status', status);
+  const openedBy=document.getElementById('openedBy').value.trim(); if(openedBy) params.set('openedBy', openedBy);
+  const closedBy=document.getElementById('closedBy').value.trim(); if(closedBy) params.set('closedBy', closedBy);
+  const dept=document.getElementById('department').value; if(dept) params.set('departmentId', dept);
+  const kw=document.getElementById('keyword').value.trim(); if(kw) params.set('keyword', kw);
+  const res = await fetch('/api/tickets/search?'+params.toString(), {headers: authHeaders()});
+  const data = await res.json();
+  const tbody=document.querySelector('#results tbody');
+  tbody.innerHTML='';
+  data.forEach((t,idx)=>{
+    const dept=departments.find(d=>d.id===t.departmentId);
+    const tr=document.createElement('tr');
+    tr.innerHTML=`<td>${idx+1}</td><td>${t.description}</td><td>${t.room}</td><td>${dept?dept.name:''}</td><td>${t.openedBy||''}</td><td>${t.closedBy||''}</td><td>${formatDate(t.openedAt)}</td><td>${formatDate(t.closedAt)}</td><td>${t.isClosed?'Closed':'Open'}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+document.getElementById('searchForm').addEventListener('submit', e=>{e.preventDefault(); searchTickets();});
+loadDepartments();
+</script>
+</body>
+</html>

--- a/frontend/tickets.html
+++ b/frontend/tickets.html
@@ -57,20 +57,7 @@
   </div>
 
   <div class="mt-4">
-    <div class="row g-2 mb-2">
-      <div class="col-auto">
-        <input type="date" id="fromDate" class="form-control" />
-      </div>
-      <div class="col-auto">
-        <input type="date" id="toDate" class="form-control" />
-      </div>
-      <div class="col-auto">
-        <input type="text" id="closedRoom" class="form-control" data-i18n-placeholder="room" />
-      </div>
-      <div class="col-auto">
-        <button id="showClosed" class="btn btn-secondary" data-i18n="showClosed">Show closed tickets</button>
-      </div>
-    </div>
+    <h3 data-i18n="closedTodayHeading">תקלות שנסגרו היום</h3>
     <div class="table-responsive">
       <table id="closedTable" class="table table-bordered table-sm">
         <thead>
@@ -154,7 +141,8 @@ const translations = {
       deleteConfirm: 'Delete this ticket?',
       delete: 'Delete',
       departmentRequired: 'Department required',
-      ticketAdded: 'Ticket added successfully!'
+      ticketAdded: 'Ticket added successfully!',
+      closedTodayHeading: 'Tickets closed today'
     },
     he: {
     title: 'Hotel Sharon - TicketBox',
@@ -194,7 +182,8 @@ const translations = {
       deleteConfirm: '\u05DC\u05DE\u05D7\u05D5\u05E7 \u05D0\u05EA \u05D4\u05EA\u05E7\u05DC\u05D4?',
       delete: '\u05DE\u05D7\u05D9\u05E7\u05D4',
       departmentRequired: '\u05DE\u05D7\u05DC\u05E7\u05D4 \u05E0\u05D3\u05E8\u05E9\u05EA',
-      ticketAdded: '\u05D4\u05EA\u05E7\u05DC\u05D4 \u05E0\u05D5\u05E1\u05E4\u05D4 \u05D1\u05D4\u05E6\u05DC\u05D7\u05D4!'
+      ticketAdded: '\u05D4\u05EA\u05E7\u05DC\u05D4 \u05E0\u05D5\u05E1\u05E4\u05D4 \u05D1\u05D4\u05E6\u05DC\u05D7\u05D4!',
+      closedTodayHeading: '\u05EA\u05E7\u05DC\u05D5\u05EA \u05E9\u05E0\u05E1\u05D2\u05E8\u05D5 \u05D4\u05D9\u05D5\u05DD'
     },
     ru: {
     title: 'Hotel Sharon - TicketBox',
@@ -227,9 +216,10 @@ const translations = {
     editTicket: '\u0420\u0435\u0434\u0430\u043A\u0442\u0438\u0440\u043E\u0432\u0430\u0442\u044C \u0437\u0430\u044F\u0432\u043A\u0443',
     deleteConfirm: "\u0423\u0434\u0430\u043B\u0438\u0442\u044C \u044d\u0442\u0443 \u0437\u0430\u044F\u0432\u043A\u0443?",
     delete: "\u0423\u0434\u0430\u043B\u0438\u0442\u044C",
-    departmentRequired: '\u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u043E\u0442\u0434\u0435\u043B',
-    ticketAdded: '\u0417\u0430\u044F\u0432\u043A\u0430 \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0434\u043E\u0431\u0430\u0432\u043B\u0435\u043D\u0430!',
-    openStatus: '\u041E\u0442\u043A\u0440\u044B\u0442\u0430',
+      departmentRequired: '\u0422\u0440\u0435\u0431\u0443\u0435\u0442\u0441\u044F \u043E\u0442\u0434\u0435\u043B',
+      ticketAdded: '\u0417\u0430\u044F\u0432\u043A\u0430 \u0443\u0441\u043F\u0435\u0448\u043D\u043E \u0434\u043E\u0431\u0430\u0432\u043B\u0435\u043D\u0430!',
+      closedTodayHeading: '\u0417\u0430\u043A\u0440\u044B\u0442\u044B\u0435 \u0441\u0435\u0433\u043E\u0434\u043D\u044F'
+      openStatus: '\u041E\u0442\u043A\u0440\u044B\u0442\u0430',
       closedStatus: '\u0417\u0430\u043A\u0440\u044B\u0442\u0430',
       close: '\u0417\u0430\u043A\u0440\u044B\u0442\u044C',
       reopen: '\u041E\u0442\u043A\u0440\u044B\u0442\u044C \u0437\u0430\u043D\u043E\u0432\u043E',
@@ -529,12 +519,9 @@ async function openEdit(ticket) {
 
 async function loadClosedTickets() {
   const params = new URLSearchParams();
-  const room = document.getElementById('closedRoom').value.trim();
-  if (room) params.set('room', room);
-  const from = document.getElementById('fromDate').value;
-  const to = document.getElementById('toDate').value;
-  if (from) params.set('from', from);
-  if (to) params.set('to', to);
+  const today = new Date().toISOString().slice(0,10);
+  params.set('from', today);
+  params.set('to', today);
   const res = await fetch('/api/tickets/closed?' + params.toString(), { headers: authHeaders() });
   const data = await res.json();
   const tbody = document.querySelector('#closedTable tbody');
@@ -600,6 +587,7 @@ document.getElementById('addForm').addEventListener('submit', async e => {
 
 setLang(getLang());
 setupSorting();
+loadClosedTickets();
 
 const deptForm = document.getElementById('deptForm');
 if (deptForm) {
@@ -611,7 +599,6 @@ if (deptForm) {
   });
 }
 
-document.getElementById('showClosed').addEventListener('click', loadClosedTickets);
 document.getElementById('editForm').addEventListener('submit', async e => {
   e.preventDefault();
   if (!editId) return;


### PR DESCRIPTION
## Summary
- add `/api/tickets/search` endpoint and new search page
- display daily closed tickets automatically
- show Search link for admins and superusers

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685393d7d58c832fa97c4d8c745e279e