### PR TITLE
Fix logo height and open tickets filter

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -283,7 +283,8 @@ app.get('/api/tickets', async (req, res) => {
   const query = {};
   if (req.query.status) {
     const open = req.query.status === 'open';
-    query.isClosed = !open ? true : false;
+    // include documents missing `isClosed` when fetching open tickets
+    query.isClosed = open ? { $ne: true } : true;
   }
   if (req.query.room) query.room = req.query.room;
   if (req.user && req.user.role !== 'admin' && req.user.role !== 'superuser') {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -390,6 +390,14 @@ tbody tr.divider td {
   }
 }
 
+@media (min-width: 768px) {
+  .logo img,
+  .logo-container img,
+  .logo-img {
+    max-height: 120px;
+  }
+}
+
 .logo-container {
   padding-top: 10px;
   padding-bottom: 10px;


### PR DESCRIPTION
## Summary
- keep hotel logo compact on desktops
- return open tickets even when `isClosed` field is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685399f734dc832fb4a2b4b8501f7940