### PR TITLE
Add Cloudinary support for news images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 MONGODB_URI=mongodb+srv://tanskiyv:34x6SZVWFvLpTH1O@cluster0.u47vbi5.mongodb.net/ticketbox?retryWrites=true&w=majority&appName=Cluster0
 DEFAULT_ADMIN_USERNAME=admin
 DEFAULT_ADMIN_PASSWORD=admin
+CLOUDINARY_CLOUD_NAME=
+CLOUDINARY_API_KEY=
+CLOUDINARY_API_SECRET=

--- a/backend/index.js
+++ b/backend/index.js
@@ -5,6 +5,8 @@ const fs = require('fs');
 const crypto = require('crypto');
 const bcrypt = require('bcryptjs');
 const multer = require('multer');
+const cloudinary = require('cloudinary').v2;
+const { CloudinaryStorage } = require('multer-storage-cloudinary');
 const mongoose = require('mongoose');
 const { Ticket, User, Department, Photo, News } = require('./models');
 
@@ -33,23 +35,23 @@ const UPLOAD_DIR = path.join(DATA_DIR, 'uploads');
 if (!fs.existsSync(UPLOAD_DIR)) {
   fs.mkdirSync(UPLOAD_DIR, { recursive: true });
 }
-const NEWS_UPLOAD_DIR = path.join(UPLOAD_DIR, 'news');
-if (!fs.existsSync(NEWS_UPLOAD_DIR)) {
-  fs.mkdirSync(NEWS_UPLOAD_DIR, { recursive: true });
-}
+cloudinary.config({
+  cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+  api_key: process.env.CLOUDINARY_API_KEY,
+  api_secret: process.env.CLOUDINARY_API_SECRET,
+});
+
 
 const app = express();
 const upload = multer({ dest: UPLOAD_DIR });
-const newsUpload = multer({
-  storage: multer.diskStorage({
-    destination: NEWS_UPLOAD_DIR,
-    filename: (req, file, cb) => {
-      const ext = path.extname(file.originalname);
-      const name = Date.now() + '-' + Math.round(Math.random() * 1e9) + ext;
-      cb(null, name);
-    }
-  })
+const newsStorage = new CloudinaryStorage({
+  cloudinary,
+  params: {
+    folder: 'ticketbox_news',
+    allowed_formats: ['jpg', 'png', 'jpeg', 'webp'],
+  },
 });
+const newsUpload = multer({ storage: newsStorage });
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const sessions = {}; // token -> { userId, expires }
@@ -497,7 +499,7 @@ app.post('/api/news', requireAdminOrSuperuser, newsUpload.single('image'), async
   const news = await News.create({
     title,
     content,
-    imageUrl: req.file ? '/uploads/news/' + req.file.filename : ''
+    imageUrl: req.file ? req.file.path : ''
   });
   res.json(news);
 });

--- a/frontend/admin.html
+++ b/frontend/admin.html
@@ -444,6 +444,7 @@ function renderNewsList() {
     if(n.imageUrl){
       const img = document.createElement('img');
       img.src = n.imageUrl;
+      img.alt = 'News image';
       img.className = 'img-fluid rounded mb-2';
       div.appendChild(img);
     }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -31,7 +31,7 @@ async function loadNews(){
       if(n.imageUrl){
         const img = document.createElement('img');
         img.src = n.imageUrl;
-        img.alt = 'News Image';
+        img.alt = 'News image';
         img.className = 'img-fluid rounded mb-3';
         div.appendChild(img);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "1.0.0",
       "dependencies": {
         "bcryptjs": "^3.0.2",
+        "cloudinary": "^1.37.2",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "mongoose": "^7.6.1",
-        "multer": "^1.4.5-lts.1"
+        "multer": "^1.4.5-lts.1",
+        "multer-storage-cloudinary": "^4.0.0"
       },
       "devDependencies": {
         "jest": "^30.0.0",
@@ -2147,6 +2149,30 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/cloudinary": {
+      "version": "1.41.3",
+      "resolved": "https://registry.npmjs.org/cloudinary/-/cloudinary-1.41.3.tgz",
+      "integrity": "sha512-4o84y+E7dbif3lMns+p3UW6w6hLHEifbX/7zBJvaih1E9QNMZITENQ14GPYJC4JmhygYXsuuBb9bRA3xWEoOfg==",
+      "license": "MIT",
+      "dependencies": {
+        "cloudinary-core": "^2.13.0",
+        "core-js": "^3.30.1",
+        "lodash": "^4.17.21",
+        "q": "^1.5.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/cloudinary-core": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/cloudinary-core/-/cloudinary-core-2.13.1.tgz",
+      "integrity": "sha512-z53GPNWnvU0Zi+ns8CIVbZBfj7ps/++zDvwIyiFuq5p1MoK+KUCg0k5mBceDDHTnx1gHmHUd9aohS+gDxPNt6w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "lodash": ">=4.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2286,6 +2312,17 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.43.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
+      "integrity": "sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -4136,6 +4173,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4695,6 +4738,15 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/multer-storage-cloudinary": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/multer-storage-cloudinary/-/multer-storage-cloudinary-4.0.0.tgz",
+      "integrity": "sha512-25lm9R6o5dWrHLqLvygNX+kBOxprzpmZdnVKH4+r68WcfCt8XV6xfQaMuAg+kUE5Xmr8mJNA4gE0AcBj9FJyWA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "cloudinary": "^1.21.0"
+      }
+    },
     "node_modules/napi-postinstall": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.2.4.tgz",
@@ -5133,6 +5185,17 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
     },
     "node_modules/qs": {
       "version": "6.13.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "mongoose": "^7.6.1",
-    "multer": "^1.4.5-lts.1"
+    "multer": "^1.4.5-lts.1",
+    "cloudinary": "^1.37.2",
+    "multer-storage-cloudinary": "^4.0.0"
   },
   "devDependencies": {
     "jest": "^30.0.0",


### PR DESCRIPTION
## Summary
- integrate Cloudinary and multer-storage-cloudinary in backend
- store uploaded news image URLs from Cloudinary
- show images with alt text across frontend
- document new Cloudinary environment variables
- include Cloudinary dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853a93c1a88832f8409048b783a04c0