### PR TITLE
Fix image upload and preview

### DIFF
--- a/frontend/admin-news.html
+++ b/frontend/admin-news.html
@@ -22,7 +22,7 @@ if (!localStorage.getItem('token')) {
     <form id="newsForm" enctype="multipart/form-data" class="form-section">
       <input type="text" id="title" class="form-control mb-2" placeholder="Title" required>
       <textarea id="content" class="form-control mb-2" placeholder="Content" required></textarea>
-      <input type="file" id="image" class="form-control mb-2" accept="image/*">
+      <input type="file" id="image" name="image" class="form-control mb-2" accept="image/*">
       <button type="submit" class="btn btn-primary">Publish</button>
     </form>
   </div>

--- a/frontend/guest.html
+++ b/frontend/guest.html
@@ -40,6 +40,7 @@
           <button type="submit" class="btn btn-primary submit-button" data-i18n="submit">Submit</button>
         </form>
         <div id="success" class="alert alert-success mt-3 d-none" role="alert"></div>
+        <img id="guestImagePreview" src="" class="img-fluid rounded mt-2 d-none" />
       </div>
     </div>
   </div>
@@ -141,12 +142,18 @@
       if (file) fd.append('photo', file);
       const res = await fetch('/api/public-ticket', { method: 'POST', body: fd });
       const msg = document.getElementById('success');
+      const ticket = await res.json().catch(() => null);
       if (res.ok) {
         msg.textContent = t.success;
         msg.classList.remove('d-none');
+        if (ticket && ticket.imageUrl) {
+          const img = document.getElementById('guestImagePreview');
+          img.src = ticket.imageUrl;
+          img.classList.remove('d-none');
+        }
         e.target.reset();
       } else {
-        const err = await res.json().catch(() => ({ error: t.serverError }));
+        const err = ticket || { error: t.serverError };
         msg.textContent = err.error || t.serverError;
         msg.classList.remove('d-none');
         msg.classList.replace('alert-success','alert-danger');

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -399,7 +399,8 @@ tbody tr.divider td {
 }
 
 @media (min-width: 768px) {
-  .logo-container img {
+  .logo-container img,
+  .logo-img {
     max-height: 120px;
     width: auto;
     height: auto;


### PR DESCRIPTION
## Summary
- store news images locally and expose `/uploads/news`
- pass `imageUrl` with public ticket response
- show guest ticket image preview after submission
- ensure admin news form file input has name attribute
- tweak desktop logo styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853bc24398c832f8691ec68edea4698