### PR TITLE
Restrict user management to admins

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -218,13 +218,13 @@ app.delete('/api/departments/:id', async (req, res) => {
 });
 
 
-// Users (admin or superuser)
-app.get('/api/users', requireAdminOrSuperuser, async (req, res) => {
+// Users (admin only)
+app.get('/api/users', requireAdmin, async (req, res) => {
   const list = await User.find();
   res.json(list);
 });
 
-app.post('/api/users', requireAdminOrSuperuser, async (req, res) => {
+app.post('/api/users', requireAdmin, async (req, res) => {
   const body = req.body || {};
   const user = await User.create({
     username: body.username || '',
@@ -238,12 +238,12 @@ app.post('/api/users', requireAdminOrSuperuser, async (req, res) => {
   res.json(user);
 });
 
-app.delete('/api/users/:id', requireAdminOrSuperuser, async (req, res) => {
+app.delete('/api/users/:id', requireAdmin, async (req, res) => {
   await User.findByIdAndDelete(req.params.id);
   res.json({ ok: true });
 });
 
-app.post('/api/users/:id/password', requireAdminOrSuperuser, async (req, res) => {
+app.post('/api/users/:id/password', requireAdmin, async (req, res) => {
   const user = await User.findById(req.params.id);
   if (!user) return res.status(404).json({ error: 'not found' });
   user.passwordHash = bcrypt.hashSync(req.body.password || '1234', 10);
@@ -252,7 +252,7 @@ app.post('/api/users/:id/password', requireAdminOrSuperuser, async (req, res) =>
   res.json({ ok: true });
 });
 
-app.patch('/api/users/:id', requireAdminOrSuperuser, async (req, res) => {
+app.patch('/api/users/:id', requireAdmin, async (req, res) => {
   const user = await User.findById(req.params.id);
   if (!user) return res.status(404).json({ error: 'not found' });
   const { username, password, role, departmentId, email, name } = req.body || {};

--- a/frontend/header.js
+++ b/frontend/header.js
@@ -56,7 +56,7 @@
         window.location.href = '/login.html';
       });
       if(user.role === 'admin' && adminLink) adminLink.classList.remove('d-none');
-      if(usersLinks.length && (user.role === 'admin' || user.role === 'superuser')) usersLinks.forEach(l=>l.classList.remove('d-none'));
+      if(usersLinks.length && user.role === 'admin') usersLinks.forEach(l=>l.classList.remove('d-none'));
       if(faultLink) faultLink.classList.remove('d-none');
     } else {
       link.textContent = t.login;

--- a/frontend/users.html
+++ b/frontend/users.html
@@ -71,9 +71,9 @@ let editId = null;
 function authHeaders(){ const t = localStorage.getItem('token'); return t ? { 'Authorization':'Bearer '+t } : {}; }
 async function requireLogin(){
   const stored = localStorage.getItem('user');
-  if(stored){ const u = JSON.parse(stored); if(u.role==='admin'||u.role==='superuser'){ currentUser=u; return; } }
+  if(stored){ const u = JSON.parse(stored); if(u.role==='admin'){ currentUser=u; return; } }
   const res = await fetch('/api/me');
-  if(res.ok){ const u = await res.json(); localStorage.setItem('user', JSON.stringify(u)); if(u.role==='admin'||u.role==='superuser'){ currentUser=u; return; }}
+  if(res.ok){ const u = await res.json(); localStorage.setItem('user', JSON.stringify(u)); if(u.role==='admin'){ currentUser=u; return; }}
   localStorage.removeItem('user');
   localStorage.removeItem('token');
   window.location.href = '/login.html';


### PR DESCRIPTION
## Summary
- change `/api/users` routes to use `requireAdmin` middleware
- require admin role in `users.html`
- show user-management links only for admins

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853cb7de874832faec247d3ac697b68